### PR TITLE
feat: Basic GraphQL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,61 @@ GraphQL API Layer for Frappe Framework
 #### License
 
 MIT
+
+## Instructions
+Generate the sdls first
+```
+$ bench --site test_site graphql generate_sdl
+```
+and start making your graphql requests against:
+```
+/api/method/graphql
+```
+
+## Features
+### Filtering
+You can filter any doctype by its `name`, `standard_filters` or with a `filters` json
+
+Filtering by name is straight forward:
+```graphql
+{
+    User(name: "Administrator") {
+        name,
+        email,
+        roles {
+            role
+        }
+    }
+}
+```
+For standard filters, lets take a look at the User doctype. It has 3 standard filters:
+- `full_name`
+- `username`
+- `user_type`
+
+It is possible to query them like this:
+```graphql
+{
+    User(full_name: "Fahim") {
+        name, email
+    }
+}
+```
+
+And with `filters` json dict:
+```graphql
+{
+    User(filters: "{ \"full_name\": [\"LIKE\", \"%TEST%\"] }") {
+        name, email
+    }
+}
+```  
+
+### RolePermission integration
+Data is returned based on Read access to the resource
+
+### Generic Mutations: set_value & save_doc
+### Pagination
+### Support SDL Extensions
+https://docs.reactioncommerce.com/docs/how-to-extend-graphql-to-add-field
+### Support additional Mutations via Hooks

--- a/frappe_graphql/__init__.py
+++ b/frappe_graphql/__init__.py
@@ -2,4 +2,3 @@
 from __future__ import unicode_literals
 
 __version__ = '0.0.1'
-

--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -1,0 +1,27 @@
+import click
+import frappe
+from frappe_graphql.utils.generate_sdl import make_doctype_sdl_files
+from frappe.commands import pass_context, get_site
+
+
+@click.group()
+def graphql():
+    pass
+
+
+@click.command("generate_sdl")
+@pass_context
+def generate_sdl(context):
+    site = get_site(context=context)
+    try:
+        frappe.init(site=site)
+        frappe.connect()
+
+        target_dir = frappe.get_site_path("doctype_sdls")
+        make_doctype_sdl_files(target_dir=target_dir)
+    finally:
+        frappe.destroy()
+
+
+graphql.add_command(generate_sdl)
+commands = [graphql]

--- a/frappe_graphql/graphql.py
+++ b/frappe_graphql/graphql.py
@@ -1,0 +1,69 @@
+import frappe
+import graphql
+
+from frappe_graphql.utils.loader import load_schema_from_path
+from frappe_graphql.utils.resolver import default_doctype_resolver
+
+
+def get_schema():
+    target_dir = frappe.get_site_path("doctype_sdls")
+    schema = load_schema_from_path(target_dir)
+
+    ast_doc = graphql.parse(schema)
+    schema = graphql.build_ast_schema(ast_doc)
+    return schema
+
+
+@frappe.whitelist(allow_guest=True)
+def execute(query=None, variables=None, operation_name=None):
+    query, variables, operation_name = get_query(
+        query=query,
+        variables=variables,
+        operation_name=operation_name
+    )
+    result = graphql.graphql_sync(
+        schema=get_schema(),
+        source=query,
+        variable_values=variables,
+        operation_name=operation_name,
+        field_resolver=default_doctype_resolver
+    )
+    output = frappe._dict()
+    for k in ("data", "errors"):
+        if not getattr(result, k, None):
+            continue
+        output[k] = getattr(result, k)
+
+    if hasattr(frappe.local, "request"):
+        frappe.local.response = output
+    else:
+        return output
+
+
+def get_query(query, variables, operation_name):
+    """
+    Gets Query details as per the specs in https://graphql.org/learn/serving-over-http/
+    """
+    if query:
+        return query, variables, operation_name
+
+    if not hasattr(frappe.local, "request"):
+        return query, variables, operation_name
+
+    from werkzeug.wrappers import Request
+    request: Request = frappe.local.request
+
+    if request.method == "GET":
+        query = frappe.safe_decode(request.args["query"])
+        variables = frappe.safe_decode(request.args["variables"])
+        operation_name = frappe.safe_decode(request.args["operation_name"])
+    elif request.method == "POST":
+        if "application/json" not in (request.content_type or ""):
+            raise Exception("Please send in application/json")
+
+        graphql_request = frappe.parse_json(request.get_data(as_text=True))
+        query = graphql_request.query
+        variables = graphql_request.variables
+        operation_name = graphql_request.operationName
+
+    return query, variables, operation_name

--- a/frappe_graphql/hooks.py
+++ b/frappe_graphql/hooks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from . import __version__ as app_version
+# from . import __version__ as app_version
 
 app_name = "frappe_graphql"
 app_title = "Frappe Graphql"
@@ -46,7 +46,7 @@ app_license = "MIT"
 
 # website user home page (by Role)
 # role_home_page = {
-#	"Role": "home_page"
+#   "Role": "home_page"
 # }
 
 # Generators
@@ -72,11 +72,11 @@ app_license = "MIT"
 # Permissions evaluated in scripted ways
 
 # permission_query_conditions = {
-# 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
+#   "Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
 # }
 #
 # has_permission = {
-# 	"Event": "frappe.desk.doctype.event.event.has_permission",
+#   "Event": "frappe.desk.doctype.event.event.has_permission",
 # }
 
 # DocType Class
@@ -84,7 +84,7 @@ app_license = "MIT"
 # Override standard doctype classes
 
 # override_doctype_class = {
-# 	"ToDo": "custom_app.overrides.CustomToDo"
+#   "ToDo": "custom_app.overrides.CustomToDo"
 # }
 
 # Document Events
@@ -92,32 +92,32 @@ app_license = "MIT"
 # Hook on document methods and events
 
 # doc_events = {
-# 	"*": {
-# 		"on_update": "method",
-# 		"on_cancel": "method",
-# 		"on_trash": "method"
-#	}
+#   "*": {
+#     "on_update": "method",
+#     "on_cancel": "method",
+#     "on_trash": "method"
+#  }
 # }
 
 # Scheduled Tasks
 # ---------------
 
 # scheduler_events = {
-# 	"all": [
-# 		"frappe_graphql.tasks.all"
-# 	],
-# 	"daily": [
-# 		"frappe_graphql.tasks.daily"
-# 	],
-# 	"hourly": [
-# 		"frappe_graphql.tasks.hourly"
-# 	],
-# 	"weekly": [
-# 		"frappe_graphql.tasks.weekly"
-# 	]
-# 	"monthly": [
-# 		"frappe_graphql.tasks.monthly"
-# 	]
+#   "all": [
+#     "frappe_graphql.tasks.all"
+#   ],
+#   "daily": [
+#     "frappe_graphql.tasks.daily"
+#   ],
+#   "hourly": [
+#     "frappe_graphql.tasks.hourly"
+#   ],
+#   "weekly": [
+#     "frappe_graphql.tasks.weekly"
+#   ]
+#   "monthly": [
+#     "frappe_graphql.tasks.monthly"
+#   ]
 # }
 
 # Testing
@@ -128,18 +128,17 @@ app_license = "MIT"
 # Overriding Methods
 # ------------------------------
 #
-# override_whitelisted_methods = {
-# 	"frappe.desk.doctype.event.event.get_events": "frappe_graphql.event.get_events"
-# }
+override_whitelisted_methods = {
+    "graphql": "frappe_graphql.graphql.execute"
+}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
 # override_doctype_dashboards = {
-# 	"Task": "frappe_graphql.task.get_dashboard_data"
+#   "Task": "frappe_graphql.task.get_dashboard_data"
 # }
 
 # exempt linked doctypes from being automatically cancelled
 #
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
-

--- a/frappe_graphql/utils/exceptions/__init__.py
+++ b/frappe_graphql/utils/exceptions/__init__.py
@@ -1,0 +1,10 @@
+class GraphQLFileSyntaxError(Exception):
+    def __init__(self, schema_file, message) -> None:
+        super().__init__()
+        self.message = self.format_message(schema_file, message)
+
+    def format_message(self, schema_file, message):
+        return f"Could not load {schema_file}:\n{message}"
+
+    def __str__(self):
+        return self.message

--- a/frappe_graphql/utils/generate_sdl.py
+++ b/frappe_graphql/utils/generate_sdl.py
@@ -1,0 +1,107 @@
+import os
+import frappe
+from frappe.model import display_fieldtypes, table_fields, default_fields
+
+
+def make_doctype_sdl_files(target_dir):
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    def write_file(filename, contents):
+        target_file = os.path.join(target_dir, f"{frappe.scrub(filename)}.graphql")
+        with open(target_file, "w") as f:
+            f.write(contents)
+
+    write_file("root", get_root_sdl())
+
+    for doctype in frappe.get_all("DocType"):
+        doctype = doctype.name
+        sdl = get_doctype_sdl(doctype)
+        write_file(doctype, sdl)
+
+
+def get_root_sdl():
+    sdl = "schema {\n\tquery: Query\n}"
+
+    sdl += "\n\ninterface BaseDocType {"
+    for field in default_fields:
+        if field in ("idx", "docstatus"):
+            fieldtype = "Int"
+        else:
+            fieldtype = "String"
+        sdl += f"\n  {field}: {fieldtype}"
+    sdl += "}"
+
+    sdl += "\n\ntype Query {"
+    for doctype in frappe.get_all("DocType"):
+        doctype = doctype.name
+        sdl += f"\n  {doctype.replace(' ', '')}"
+        sdl += "(name: String, filters: String"
+
+        # if doctype in ("User", "Workflow"):
+        for field in frappe.get_meta(doctype).get("fields", {"in_standard_filter": 1}):
+            if field.fieldtype in table_fields:
+                continue
+            sdl += f", {field.fieldname}: {get_graphql_type(field, ignore_reqd=True)}"
+
+        sdl += f"): [{doctype.replace(' ', '')}!]!"
+    sdl += "\n}"
+
+    return sdl
+
+
+def get_doctype_sdl(doctype):
+    meta = frappe.get_meta(doctype)
+    sdl = f"type {doctype.replace(' ', '')} implements BaseDocType {{"
+
+    defined_fieldnames = [] + list(default_fields)
+
+    for field in default_fields:
+        if field in ("idx", "docstatus"):
+            fieldtype = "Int"
+        else:
+            fieldtype = "String"
+        sdl += f"\n  {field}: {fieldtype}"
+
+    for field in meta.fields:
+        if field.fieldtype in display_fieldtypes:
+            continue
+        if field.fieldname in defined_fieldnames:
+            continue
+        defined_fieldnames.append(field.fieldname)
+        sdl += f"\n  {get_field_sdl(field)}"
+
+    sdl += "\n}"
+    return sdl
+
+
+def get_field_sdl(docfield):
+    return f"{docfield.fieldname}: {get_graphql_type(docfield)}"
+
+
+def get_graphql_type(docfield, ignore_reqd=False):
+    string_fieldtypes = [
+        "Small Text", "Long Text", "Code", "Text Editor", "Markdown Editor",
+        "HTML Editor", "Date", "Datetime", "Time", "Text", "Data", "Link",
+        "Dynamic Link", "Password", "Select", "Rating", "Read Only",
+        "Attach", "Attach Image", "Signature", "Color", "Barcode", "Geolocation", "Duration"
+    ]
+    int_fieldtypes = ["Int", "Long Int", "Check"]
+    float_fieldtypes = ["Currency", "Float", "Percent"]
+
+    graphql_type = None
+    if docfield.fieldtype in string_fieldtypes:
+        graphql_type = "String"
+    elif docfield.fieldtype in int_fieldtypes:
+        graphql_type = "Int"
+    elif docfield.fieldtype in float_fieldtypes:
+        graphql_type = "String"
+    elif docfield.fieldtype in table_fields:
+        graphql_type = f"[{docfield.options.replace(' ', '')}!]!"
+    else:
+        frappe.throw(f"Invalid fieldtype: {docfield.fieldtype}")
+
+    if not ignore_reqd and docfield.reqd and graphql_type[-1] != "!":
+        graphql_type += "!"
+
+    return graphql_type

--- a/frappe_graphql/utils/loader.py
+++ b/frappe_graphql/utils/loader.py
@@ -1,0 +1,32 @@
+import os
+from typing import Generator
+
+from graphql import parse
+from graphql.error import GraphQLSyntaxError
+
+from .exceptions import GraphQLFileSyntaxError
+
+
+def load_schema_from_path(path: str) -> str:
+    if os.path.isdir(path):
+        schema_list = [read_graphql_file(f) for f in sorted(walk_graphql_files(path))]
+        return "\n".join(schema_list)
+    return read_graphql_file(os.path.abspath(path))
+
+
+def walk_graphql_files(path: str) -> Generator[str, None, None]:
+    extension = ".graphql"
+    for dirpath, _, files in os.walk(path):
+        for name in files:
+            if extension and name.lower().endswith(extension):
+                yield os.path.join(dirpath, name)
+
+
+def read_graphql_file(path: str) -> str:
+    with open(path, "r") as graphql_file:
+        schema = graphql_file.read()
+    try:
+        parse(schema)
+    except GraphQLSyntaxError as e:
+        raise GraphQLFileSyntaxError(path, str(e)) from e
+    return schema

--- a/frappe_graphql/utils/resolver.py
+++ b/frappe_graphql/utils/resolver.py
@@ -1,0 +1,33 @@
+from typing import Any
+import frappe
+from graphql import GraphQLObjectType, GraphQLResolveInfo
+
+
+def default_doctype_resolver(obj: Any, info: GraphQLResolveInfo, **kwargs):
+    parent_type: GraphQLObjectType = info.parent_type
+    if not isinstance(info.parent_type, GraphQLObjectType):
+        frappe.throw("Invalid GraphQL")
+
+    if parent_type.name == "Query" and info.path[0] is None:
+        # root doctype query
+        doctype = get_doctype(info.path[1])
+        if not frappe.has_permission(doctype=doctype):
+            return []
+        filters = frappe._dict()
+        if kwargs and len(kwargs.keys()):
+            if "filters" in kwargs:
+                filters = frappe.parse_json(kwargs.get("filters"))
+            else:
+                filters = kwargs
+        return frappe.get_list(doctype, filters=filters)
+    elif len(info.path) == 3:
+        doctype = get_doctype(parent_type.name)
+        if not frappe.has_permission(doctype=doctype):
+            return []
+        cached_doc = frappe.get_cached_doc(doctype, obj.name)
+        return cached_doc.get(info.field_name)
+
+
+def get_doctype(name):
+    valid_doctypes = [x.name for x in frappe.get_all("DocType")]
+    return [x for x in valid_doctypes if x.replace(" ", "") == name][0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 frappe
+graphql-core==3.1.3


### PR DESCRIPTION
- Follows the HTTP Spec mentioned here: https://graphql.org/learn/serving-over-http/
- Supports Reading from all the DocTypes
- Checks Role Permissions before returning Data
- Supports graphql variables & operationNames