### PR TITLE
feat: performance improvement

### DIFF
--- a/frappe_graphql/cache.py
+++ b/frappe_graphql/cache.py
@@ -1,0 +1,7 @@
+import frappe
+
+from frappe_graphql.utils.loader import FRAPPE_GRAPHQL_SCHEMA_REDIS_KEY
+
+
+def clear_cache():
+    frappe.cache().delete_value(keys=[FRAPPE_GRAPHQL_SCHEMA_REDIS_KEY])

--- a/frappe_graphql/hooks.py
+++ b/frappe_graphql/hooks.py
@@ -142,3 +142,5 @@ override_whitelisted_methods = {
 # exempt linked doctypes from being automatically cancelled
 #
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
+
+clear_cache = "frappe_graphql.cache.clear_cache"


### PR DESCRIPTION
**Note: For the best possible results _Developer mode is 0_ in following cases**

1. Export all doctype types in default directory (bench --site test-site graphql generate_sdl) and query:

Before:
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/41537985/112752304-7a788900-8fe3-11eb-98aa-32bbb6041f14.png">

After:
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/41537985/112752426-fd99df00-8fe3-11eb-9ef4-e5a2cbdc56ee.png">

2. Export only required doctype types (bench --site test-site graphql generate_sdl --output-dir --app) and query:

Before:
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/41537985/112752743-806f6980-8fe5-11eb-8a4f-4af9242d2f9a.png">


After:
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/41537985/112752681-3ab2a100-8fe5-11eb-97a4-5467e949deea.png">

