### PR TITLE
refactor: ignore custom fields flag + extend doctype if custom field

### DIFF
--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -18,9 +18,12 @@ def graphql():
 @click.option("--doctype", "-dt", multiple=True,
               help="Doctype to generate sdls for. You can specify multiple")
 @click.option("--ignore-root-file", is_flag=True, default=False, help="Ignore root.graphql")
+@click.option("--ignore-custom-fields", is_flag=True, default=False,
+              help="Ignore custom fields generation")
 @pass_context
 def generate_sdl(
-    context, output_dir=None, app=None, module=None, doctype=None, ignore_root_file=False
+    context, output_dir=None, app=None, module=None, doctype=None,
+    ignore_root_file=False, ignore_custom_fields=False
 ):
     site = get_site(context=context)
     try:
@@ -39,7 +42,8 @@ def generate_sdl(
             app=app,
             modules=list(module),
             doctypes=list(doctype),
-            ignore_root_file=ignore_root_file
+            ignore_root_file=ignore_root_file,
+            ignore_custom_fields=ignore_custom_fields
         )
     finally:
         frappe.destroy()


### PR DESCRIPTION
2 additions:
1. now custom fields will be generated as follows
```
extend type TODO {
  custom_field1: Int
}
```
2. flag to ignore generation of custom fields