### PR TITLE
feat: Support for multipart/form-data requests + uploadFile Mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ and start making your graphql requests against:
 # Features
 ## Getting single Document and getting a filtered doctype list
 You can get a single document by its name using `<doctype>` query.  
+For sort by fields, only those fields that are search_indexed / unique can be used. NAME, CREATION & MODIFIED can also be used
+<details>
+<summary>Example</summary>
+
+Query
 ```
 {
     User(name: "Administrator") {
@@ -49,11 +54,16 @@ You can get a list of documents by querying `<doctype-plural>`. You can also pas
     }
 }
 ```
-For sort by fields, only those fields that are search_indexed / unique can be used. NAME, CREATION & MODIFIED can also be used
-  
+</details>
+<hr/>
+
 ## Access Field Linked Documents in nested queries
 All Link fields return respective doc. Add `__name` suffix to the link field name to get the link name.
-```
+<details>
+<summary>Example</summary>
+
+Query
+```gql
 {
     ToDo (limit_page_length: 1) {
         name,
@@ -101,17 +111,73 @@ Result
     }
 }
 ```
+</details>
+<hr/>
+
+## File Uploads
+File uploads can be done following the [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec). `uploadFile` mutation is included implementing the same
+
+<details>
+<summary>Example</summary>
+
+Query
+```http
+POST /api/method/graphql HTTP/1.1
+Host: test_site:8000
+Accept: application/json
+Cookie: full_name=Administrator; sid=<sid>; system_user=yes; user_id=Administrator; user_image=
+Content-Length: 553
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+----WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="operations"
+
+{
+  "query": "mutation uploadFile($file: Upload!) { uploadFile(file: $file) { name, file_url  } }",
+  "variables": {
+    "file": null
+  }
+}
+----WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="map"
+
+{ "0": ["variables.file"] }
+----WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="0"; filename="/D:/faztp12/Pictures/BingImageOfTheDay_20190715.jpg"
+Content-Type: image/jpeg
+
+(data)
+----WebKitFormBoundary7MA4YWxkTrZu0gW
+```
+
+Response
+```json
+{
+    "data": {
+        "uploadFile": {
+            "name": "ce36b2e222",
+            "file_url": "/files/BingImageOfTheDay_20190715.jpg"
+        }
+    }
+}
+```
+</details>
+
+<hr/>
 
 ## RolePermission integration
 Data is returned based on Read access to the resource
+<hr/>
 
 ## Standard Mutations: set_value , save_doc & delete_doc
 - [SET_VALUE Mutation](./docs/SET_VALUE.md)
 - [SAVE_DOC Mutation](./docs/SAVE_DOC.md)
 - [DELETE_DOC Mutation](./docs/DELETE_DOC.md)
+<hr/>
 
 ## Pagination
 Cursor based pagination is implemented. You can read more about it here: [Cursor Based Pagination](./docs/cursor_pagination.md)
+<hr/>
 
 ## Support Extensions via Hooks
 You can extend the SDLs with additional query / mutations / subscriptions. Examples are provided for a specific set of Scenarios. Please read [GraphQL Spec](http://spec.graphql.org/June2018/#sec-Object-Extensions) regarding Extending types. There are mainly two hooks introduced:
@@ -131,6 +197,7 @@ The above will look for graphql files in `your-bench/apps/your-app/your-app/gene
 - `graphql_schema_processors`  
 You can pass in a list of cmd that gets executed on schema creation. You are given `GraphQLSchema` object (please refer [graphql-core](https://github.com/graphql-python/graphql-core)) as the only parameter. You can modify it or extend it as per your requirements.
 This is a good place to attach the resolvers for the custom SDLs defined via `graphql_sdl_dir`
+<hr/>
 
 ## Examples
 ### Adding a newly created DocType

--- a/frappe_graphql/utils/file.py
+++ b/frappe_graphql/utils/file.py
@@ -9,7 +9,7 @@ def make_file_document(file_key, doctype=None, docname=None, fieldname=None, is_
         if frappe.get_system_settings('allow_guests_to_upload_files'):
             ignore_permissions = True
         else:
-            return
+            raise frappe.PermissionError("Guest uploads are not allowed")
     else:
         user = frappe.get_doc("User", frappe.session.user)
         ignore_permissions = False

--- a/frappe_graphql/utils/file.py
+++ b/frappe_graphql/utils/file.py
@@ -1,0 +1,45 @@
+import frappe
+from frappe.utils import cint
+from frappe.handler import ALLOWED_MIMETYPES
+
+
+def make_file_document(file_key, doctype=None, docname=None, fieldname=None, is_private=None):
+    user = None
+    if frappe.session.user == 'Guest':
+        if frappe.get_system_settings('allow_guests_to_upload_files'):
+            ignore_permissions = True
+        else:
+            return
+    else:
+        user = frappe.get_doc("User", frappe.session.user)
+        ignore_permissions = False
+
+    files = frappe.request.files
+    content = None
+    filename = None
+
+    if file_key in files:
+        file = files[file_key]
+        content = file.stream.read()
+        filename = file.filename
+
+    frappe.local.uploaded_file = content
+    frappe.local.uploaded_filename = filename
+
+    if frappe.session.user == 'Guest' or (user and not user.has_desk_access()):
+        import mimetypes
+        filetype = mimetypes.guess_type(filename)[0]
+        if filetype not in ALLOWED_MIMETYPES:
+            frappe.throw(frappe._("You can only upload JPG, PNG, PDF, or Microsoft documents."))
+
+    ret = frappe.get_doc({
+        "doctype": "File",
+        "attached_to_doctype": doctype,
+        "attached_to_name": docname,
+        "attached_to_field": fieldname,
+        "file_name": filename,
+        "is_private": cint(is_private),
+        "content": content
+    })
+    ret.save(ignore_permissions=ignore_permissions)
+    return ret

--- a/frappe_graphql/utils/generate_sdl/root.py
+++ b/frappe_graphql/utils/generate_sdl/root.py
@@ -84,6 +84,8 @@ def get_pagination_types():
 
 def get_mutations():
     return """\n
+scalar Upload
+
 type SET_VALUE_TYPE {
     doctype: String!
     name: String!
@@ -108,5 +110,7 @@ type Mutation {
     setValue(doctype: String!, name: String!, fieldname: String!, value: String): SET_VALUE_TYPE
     saveDoc(doctype: String!, doc: String!): SAVE_DOC_TYPE
     deleteDoc(doctype: String!, name: String!): DELETE_DOC_TYPE
+    uploadFile(file: Upload!, is_private: Boolean, attached_to_doctype: String,
+        attached_to_name: String, fieldname: String): File
 }
 """

--- a/frappe_graphql/utils/resolver/mutations.py
+++ b/frappe_graphql/utils/resolver/mutations.py
@@ -8,6 +8,7 @@ def bind_mutation_resolvers(schema: GraphQLSchema):
     mutation_type.fields["setValue"].resolve = set_value_resolver
     mutation_type.fields["saveDoc"].resolve = save_doc_resolver
     mutation_type.fields["deleteDoc"].resolve = delete_doc_resolver
+    mutation_type.fields["uploadFile"].resolve = file_upload_resolver
 
     SET_VALUE_TYPE: GraphQLObjectType = mutation_type.fields["setValue"].type
     SAVE_DOC_TYPE: GraphQLObjectType = mutation_type.fields["saveDoc"].type
@@ -69,3 +70,17 @@ def delete_doc_resolver(obj, info: GraphQLResolveInfo, **kwargs):
         "name": name,
         "success": True
     }
+
+
+def file_upload_resolver(obj, info: GraphQLResolveInfo, **kwargs):
+    from frappe_graphql.utils.file import make_file_document
+
+    file_doc = make_file_document(
+        file_key=kwargs.get("file"),
+        is_private=1 if kwargs.get("is_private") else 0,
+        doctype=kwargs.get("attached_to_doctype"),
+        docname=kwargs.get("attached_to_name"),
+        fieldname=kwargs.get("fieldname"),
+    )
+
+    return file_doc


### PR DESCRIPTION
Implements the form multi part spec presented here: https://github.com/jaydenseric/graphql-multipart-request-spec
The same spec is implemented by apollo-graphql & saleor

Example:
<details><summary>Request</summary>

```http
POST /api/method/graphql HTTP/1.1
Host: romman_dev:8000
Accept: application/json
Cookie: full_name=Administrator; sid=cdfc5b283b8bc863a431dc7f5e67a3b83c7240dfef5a3d0195ad1989; system_user=yes; user_id=Administrator; user_image=
Content-Length: 553
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW

----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="operations"

{
  "query": "mutation uploadFile($file: Upload!) { uploadFile(file: $file) { name, file_url  } }",
  "variables": {
    "file": null
  }
}
----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="map"

{ "0": ["variables.file"] }
----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="0"; filename="/D:/faztp12/Pictures/BingImageOfTheDay_20190715.jpg"
Content-Type: image/jpeg

(data)
----WebKitFormBoundary7MA4YWxkTrZu0gW

```
</details>

<details><summary>Response</summary>

```json
{
    "data": {
        "uploadFile": {
            "name": "ce36b2e222",
            "file_url": "/files/BingImageOfTheDay_20190715.jpg"
        }
    }
}
```
</details>