### PR TITLE
feat: Auto translate fields in DocResolver + addTranslation Mutation

### DIFF
--- a/frappe_graphql/frappe_graphql/mutations/add_translation.py
+++ b/frappe_graphql/frappe_graphql/mutations/add_translation.py
@@ -16,7 +16,6 @@ def add_translation_resolver(obj, info: GraphQLResolveInfo, **kwargs):
     docname = kwargs.get("docname")
     docfield = kwargs.get("docfield")
 
-    context = None
     if doctype:
         context = doctype
 

--- a/frappe_graphql/frappe_graphql/mutations/add_translation.py
+++ b/frappe_graphql/frappe_graphql/mutations/add_translation.py
@@ -14,11 +14,17 @@ def add_translation_resolver(obj, info: GraphQLResolveInfo, **kwargs):
     context = kwargs.get("context")
     doctype = kwargs.get("doctype")
     docname = kwargs.get("docname")
+    docfield = kwargs.get("docfield")
+
+    context = None
+    if doctype:
+        context = doctype
 
     if doctype and docname:
-        context = f"{doctype}:{docname}"
-    elif doctype:
-        context = doctype
+        context += f":{docname}"
+
+    if doctype and docfield:
+        context += f":{docfield}"
 
     tr_doc = frappe.get_doc(frappe._dict(
         doctype="Translation",

--- a/frappe_graphql/frappe_graphql/mutations/add_translation.py
+++ b/frappe_graphql/frappe_graphql/mutations/add_translation.py
@@ -1,0 +1,31 @@
+from graphql import GraphQLSchema, GraphQLResolveInfo
+
+import frappe
+
+
+def bind(schema: GraphQLSchema):
+    schema.mutation_type.fields["addTranslation"].resolve = add_translation_resolver
+
+
+def add_translation_resolver(obj, info: GraphQLResolveInfo, **kwargs):
+    language = kwargs.get("language")
+    source_text = kwargs.get("source_text")
+    translated_text = kwargs.get("translated_text")
+    context = kwargs.get("context")
+    doctype = kwargs.get("doctype")
+    docname = kwargs.get("docname")
+
+    if doctype and docname:
+        context = f"{doctype}:{docname}"
+    elif doctype:
+        context = doctype
+
+    tr_doc = frappe.get_doc(frappe._dict(
+        doctype="Translation",
+        language=language,
+        source_text=source_text,
+        translated_text=translated_text,
+        context=context
+    )).insert()
+
+    return tr_doc

--- a/frappe_graphql/frappe_graphql/mutations/add_translation.py
+++ b/frappe_graphql/frappe_graphql/mutations/add_translation.py
@@ -25,12 +25,21 @@ def add_translation_resolver(obj, info: GraphQLResolveInfo, **kwargs):
     if doctype and docfield:
         context += f":{docfield}"
 
-    tr_doc = frappe.get_doc(frappe._dict(
-        doctype="Translation",
+    existing_tr = frappe.db.get_value("Translation", frappe._dict(
         language=language,
         source_text=source_text,
-        translated_text=translated_text,
         context=context
-    )).insert()
+    ))
+    if existing_tr:
+        frappe.set_value("Translation", existing_tr, "translated_text", translated_text)
+        tr_doc = frappe.get_doc("Translation", existing_tr)
+    else:
+        tr_doc = frappe.get_doc(frappe._dict(
+            doctype="Translation",
+            language=language,
+            source_text=source_text,
+            translated_text=translated_text,
+            context=context
+        )).insert()
 
     return tr_doc

--- a/frappe_graphql/frappe_graphql/types/root.graphql
+++ b/frappe_graphql/frappe_graphql/types/root.graphql
@@ -50,6 +50,9 @@ type Mutation {
 
     uploadFile(file: Upload!, is_private: Boolean, attached_to_doctype: String,
         attached_to_name: String, fieldname: String): File
+
+    addTranslation(language: String!, source_text: String!, translated_text: String!,
+      context: String, doctype: String, docname: String): Translation!
 }
 
 type Query {

--- a/frappe_graphql/frappe_graphql/types/root.graphql
+++ b/frappe_graphql/frappe_graphql/types/root.graphql
@@ -52,7 +52,7 @@ type Mutation {
         attached_to_name: String, fieldname: String): File
 
     addTranslation(language: String!, source_text: String!, translated_text: String!,
-      context: String, doctype: String, docname: String): Translation!
+      context: String, doctype: String, docname: String, docfield: String): Translation!
 }
 
 type Query {

--- a/frappe_graphql/frappe_graphql/types/translation.graphql
+++ b/frappe_graphql/frappe_graphql/types/translation.graphql
@@ -1,0 +1,51 @@
+type Translation implements BaseDocType {
+  doctype: String
+  name: String
+  owner: User!
+  creation: String
+  modified: String
+  modified_by: User!
+  parent: String
+  parentfield: String
+  parenttype: String
+  idx: Int
+  docstatus: Int
+  owner__name: String!
+  modified_by__name: String!
+  contributed: Int
+  language: Language
+  language__name: String
+  source_text: String
+  context: String
+  translated_text: String
+  contribution_status: String
+  contribution_docname: String
+}
+
+enum TranslationSortField {
+  NAME
+  CREATION
+  MODIFIED
+  LANGUAGE
+}
+
+input TranslationSortingInput {
+  direction: SortDirection!
+  field: TranslationSortField!
+}
+
+type TranslationCountableEdge {
+  cursor: String!
+  node: Translation!
+}
+
+type TranslationCountableConnection {
+  pageInfo: PageInfo!
+  totalCount: Int
+  edges: [TranslationCountableEdge!]!
+}
+
+extend type Query {
+  Translation(name: String!): Translation!
+  Translations(filter: [DBFilterInput], sortBy: TranslationSortingInput, before: String, after: String, first: Int, last: Int): TranslationCountableConnection!
+}

--- a/frappe_graphql/hooks.py
+++ b/frappe_graphql/hooks.py
@@ -25,6 +25,7 @@ graphql_schema_processors = [
     "frappe_graphql.frappe_graphql.mutations.delete_doc.bind",
 
     "frappe_graphql.frappe_graphql.mutations.upload_file.bind",
+    "frappe_graphql.frappe_graphql.mutations.add_translation.bind",
 ]
 
 # Includes in <head>

--- a/frappe_graphql/utils/generate_sdl/__init__.py
+++ b/frappe_graphql/utils/generate_sdl/__init__.py
@@ -19,7 +19,11 @@ SDL_PREDEFINED_DOCTYPES = [
     "Gender", "Has Role", "Role Profile", "Role", "Language",
 
     # File.attached_to_doctype
-    "DocType", "Module Def", "DocField", "DocPerm"
+    "DocType", "Module Def", "DocField", "DocPerm", "Domain",
+    "DocType Action", "DocType Link",
+
+    # MakeTranslation
+    "Translation"
 ]
 
 


### PR DESCRIPTION
All `translatable` fields are updated respecting the `Accept-Language` header.
Translated values are fetched with the following context precedence order:
```
        key:doctype:name
        key:parenttype:parent
        key:doctype
        key:parenttype
        key
```

Added `addTranslation` mutation
<details>
<summary>Example</summary>

Query
```gql
mutation makeTranslation($language: String!, $source_text: String!, $translated_text: String!, $context: String, $doctype: String, $docname: String) {
    addTranslation(language: $language, source_text: $source_text, translated_text: $translated_text, context: $context, doctype: $doctype, docname: $docname) {
        name
        language__name
        context
        source_text
        translated_text
    }
}
```

Variables
```json
{
    "language": "en",
    "source_text": "Hello",
    "translated_text": "Hey!",
    "doctype": "User",
    "docname": "Admin"
}
```

Response
```json
{
    "data": {
        "addTranslation": {
            "name": "4a5fc9da20",
            "language__name": "en",
            "context": "User:Admin",
            "source_text": "Hello",
            "translated_text": "Hey!"
        }
    }
}
```
</details>

Please merge #18 first.