### PR TITLE
feat: Support for parent & dynamic link fields

### DIFF
--- a/frappe_graphql/frappe_graphql/types/docfield.graphql
+++ b/frappe_graphql/frappe_graphql/types/docfield.graphql
@@ -5,7 +5,8 @@ type DocField implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/docperm.graphql
+++ b/frappe_graphql/frappe_graphql/types/docperm.graphql
@@ -5,7 +5,8 @@ type DocPerm implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/doctype.graphql
+++ b/frappe_graphql/frappe_graphql/types/doctype.graphql
@@ -5,7 +5,8 @@ type DocType implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/doctype_action.graphql
+++ b/frappe_graphql/frappe_graphql/types/doctype_action.graphql
@@ -5,7 +5,8 @@ type DocTypeAction implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/doctype_link.graphql
+++ b/frappe_graphql/frappe_graphql/types/doctype_link.graphql
@@ -5,7 +5,8 @@ type DocTypeLink implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/domain.graphql
+++ b/frappe_graphql/frappe_graphql/types/domain.graphql
@@ -5,7 +5,8 @@ type Domain implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/dynamic_link.graphql
+++ b/frappe_graphql/frappe_graphql/types/dynamic_link.graphql
@@ -1,0 +1,48 @@
+type DynamicLink implements BaseDocType {
+  doctype: String
+  name: String
+  owner: User!
+  creation: String
+  modified: String
+  modified_by: User!
+  parent: BaseDocType
+  parentfield: String
+  parenttype: String
+  idx: Int
+  docstatus: Int
+  owner__name: String!
+  modified_by__name: String!
+  parent__name: String
+  link_doctype: DocType!
+  link_doctype__name: String
+  link_name: BaseDocType!
+  link_name__name: String
+  link_title: String
+}
+
+enum DynamicLinkSortField {
+  NAME
+  CREATION
+  MODIFIED
+}
+
+input DynamicLinkSortingInput {
+  direction: SortDirection!
+  field: DynamicLinkSortField!
+}
+
+type DynamicLinkCountableEdge {
+  cursor: String!
+  node: DynamicLink!
+}
+
+type DynamicLinkCountableConnection {
+  pageInfo: PageInfo!
+  totalCount: Int
+  edges: [DynamicLinkCountableEdge!]!
+}
+
+extend type Query {
+  DynamicLink(name: String!): DynamicLink!
+  DynamicLinks(filter: [DBFilterInput], sortBy: DynamicLinkSortingInput, before: String, after: String, first: Int, last: Int): DynamicLinkCountableConnection!
+}

--- a/frappe_graphql/frappe_graphql/types/file.graphql
+++ b/frappe_graphql/frappe_graphql/types/file.graphql
@@ -5,7 +5,8 @@ type File implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/gender.graphql
+++ b/frappe_graphql/frappe_graphql/types/gender.graphql
@@ -5,7 +5,8 @@ type Gender implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/has_role.graphql
+++ b/frappe_graphql/frappe_graphql/types/has_role.graphql
@@ -5,7 +5,8 @@ type HasRole implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/language.graphql
+++ b/frappe_graphql/frappe_graphql/types/language.graphql
@@ -5,7 +5,8 @@ type Language implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/module_def.graphql
+++ b/frappe_graphql/frappe_graphql/types/module_def.graphql
@@ -5,7 +5,8 @@ type ModuleDef implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/role.graphql
+++ b/frappe_graphql/frappe_graphql/types/role.graphql
@@ -5,7 +5,8 @@ type Role implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/role_profile.graphql
+++ b/frappe_graphql/frappe_graphql/types/role_profile.graphql
@@ -5,7 +5,8 @@ type RoleProfile implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/root.graphql
+++ b/frappe_graphql/frappe_graphql/types/root.graphql
@@ -13,7 +13,8 @@ interface BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/frappe_graphql/types/user.graphql
+++ b/frappe_graphql/frappe_graphql/types/user.graphql
@@ -5,7 +5,8 @@ type User implements BaseDocType {
   creation: String
   modified: String
   modified_by: User!
-  parent: String
+  parent: BaseDocType
+  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int

--- a/frappe_graphql/utils/resolver/document_resolver.py
+++ b/frappe_graphql/utils/resolver/document_resolver.py
@@ -47,10 +47,12 @@ def document_resolver(obj, info: GraphQLResolveInfo, **kwargs):
     if info.field_name.endswith("__name"):
         fieldname = info.field_name.split("__name")[0]
         return _get_value(fieldname)
-    elif df and df.fieldtype == "Link":
+    elif df and df.fieldtype in ("Link", "Dynamic Link"):
         if not _get_value(df.fieldname):
             return None
-        return frappe._dict(name=_get_value(df.fieldname), doctype=df.options)
+        link_dt = df.options if df.fieldtype == "Link" else \
+            _get_value(df.options)
+        return frappe._dict(name=_get_value(df.fieldname), doctype=link_dt)
     else:
         return _get_value(info.field_name)
 
@@ -63,5 +65,9 @@ def get_default_field_df(fieldname):
     if fieldname in ("owner", "modified_by"):
         df.fieldtype = "Link"
         df.options = "User"
+
+    if fieldname == "parent":
+        df.fieldtype = "Dynamic Link"
+        df.options = "parenttype"
 
     return df


### PR DESCRIPTION
- Updated all `parent: String` --> `parent: BaseDocType` 
- Added `parent__name` field
- All `Dynamic Link` fields return `BaseDocType` now. `__name` fields are added similar to `Link` fields

Examples:
<details>
<summary>Get parent docs of a child row HasRole</summary>

Query
```gql
{
    HasRole(name: "42b0eb6ea4") {
        role__name
        parenttype
        parent__name
        parent {
            name
            doctype
            ... on User {
                full_name
            }
        }
    }
}
```
Response
```json
{
    "data": {
        "HasRole": {
            "role__name": "Accounts User",
            "parenttype": "User",
            "parent__name": "t5@t.com",
            "parent": {
                "name": "t5@t.com",
                "doctype": "User",
                "full_name": "T 5"
            }
        }
    }
}
```
</details>

<details>
<summary>Dynamic Link in ToDo Doctype</summary>

Query
```gql
{
    ToDo(name: "122cec40d0") {
        description
        reference_type__name
        reference_name__name
        reference_name {
            name
            doctype
            ... on User {
                full_name
            }
        }
    }
}
```
Response
```json
{
    "data": {
        "ToDo": {
            "description": "<div class=\"ql-editor read-mode\"><p>Test 1</p></div>",
            "reference_type__name": "DocType",
            "reference_name__name": "SMS Settings",
            "reference_name": {
                "name": "SMS Settings",
                "doctype": "DocType"
            }
        }
    }
}
```
</details>

Please merge #18 first.