### PR TITLE
feat: CursorPagination multi column sort + custom sort keys

### DIFF
--- a/docs/cursor_pagination.md
+++ b/docs/cursor_pagination.md
@@ -2,8 +2,6 @@
 You can pass in `first`, `last`, `after` and `before`  
 [GraphQL Documentation on Pagination](https://graphql.org/learn/pagination/)
 
-If you want to implement the same in one of your Custom queries, please check out the example here: [Custom & Nested Pagination](./nested_pagination.md)
-
 Example:
 <details>
 <summary>Query</summary>
@@ -76,3 +74,10 @@ Example:
 ```
 </p>
 </details>
+
+If you want to implement the same in one of your Custom queries, please check out the following examples here: [Custom & Nested Pagination](./nested_pagination.md)
+
+More Examples:
+- [Get Users with all the documents they `own`](./pagination_examples/users_with_ownership.md)
+- [Get Todo list sorted by assigned_user (owner) & status](./pagination_examples/todo_with_user_status_sorting.md)
+- Sort Users by number of Roles they got have assigned

--- a/docs/pagination_examples/todo_with_user_status_sorting.md
+++ b/docs/pagination_examples/todo_with_user_status_sorting.md
@@ -1,0 +1,225 @@
+# Todo sorted by Assigned User, status
+
+
+## Query & Response
+<details>
+<summary>Query</summary>
+
+```gql
+{
+    get_todo_with_user_status_sorting(first: 15, after: "", sortBy: { direction: DESC, field: USER_AND_STATUS }) {
+        totalCount
+        pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+        }
+        edges {
+            cursor
+            node {
+                doctype
+                name,
+                modified
+                ... on ToDo {
+                    owner__name,
+                    status
+                }
+            }
+        }
+    }
+}
+```
+</details>
+
+<details>
+<summary>Response</summary>
+
+```json
+{
+    "data": {
+        "get_todo_with_user_status_sorting": {
+            "totalCount": 11,
+            "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "WwogImZhenRwMTJAZ21haWwuY29tIiwKICJPcGVuIiwKICIyMDIxLTA0LTE3IDAyOjIyOjIzLjg1NjQ4NCIKXQ==",
+                "endCursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIkNsb3NlZCIsCiAiMjAyMS0wNC0xNyAwMjoyMToyOC44NDQ5MTIiCl0="
+            },
+            "edges": [
+                {
+                    "cursor": "WwogImZhenRwMTJAZ21haWwuY29tIiwKICJPcGVuIiwKICIyMDIxLTA0LTE3IDAyOjIyOjIzLjg1NjQ4NCIKXQ==",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "6f1cc1afdb",
+                        "modified": "2021-04-17 02:22:23.856484",
+                        "owner__name": "test@gmail.com",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMTYgMDI6MDk6MzUuNjE2OTk0Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "122cec40d0",
+                        "modified": "2021-04-16 02:09:35.616994",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTU6MTYuOTIyNTA0Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "d165ee497d",
+                        "modified": "2021-04-03 17:55:16.922504",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTU6MDYuODQ0NTg2Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "c7379202e7",
+                        "modified": "2021-04-03 17:55:06.844586",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTQ6MzQuOTMxNDA3Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "2c8a93cbe0",
+                        "modified": "2021-04-03 17:54:34.931407",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTQ6MjUuNjIxNTc4Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "1a13ed221f",
+                        "modified": "2021-04-03 17:54:25.621578",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTQ6MTIuNjM1NTE4Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "bf208504c4",
+                        "modified": "2021-04-03 17:54:12.635518",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTI6NTEuNjQ0MDUyIgpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "402202c9ba",
+                        "modified": "2021-04-03 17:52:51.644052",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTI6MzkuNDIxNDQ1Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "4c6e172020",
+                        "modified": "2021-04-03 17:52:39.421445",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIk9wZW4iLAogIjIwMjEtMDQtMDMgMTc6NTI6MDIuMTUxMjE2Igpd",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "307062f0ab",
+                        "modified": "2021-04-03 17:52:02.151216",
+                        "owner__name": "Administrator",
+                        "status": "Open"
+                    }
+                },
+                {
+                    "cursor": "WwogIkFkbWluaXN0cmF0b3IiLAogIkNsb3NlZCIsCiAiMjAyMS0wNC0xNyAwMjoyMToyOC44NDQ5MTIiCl0=",
+                    "node": {
+                        "doctype": "ToDo",
+                        "name": "ae6f39845b",
+                        "modified": "2021-04-17 02:21:28.844912",
+                        "owner__name": "Administrator",
+                        "status": "Closed"
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+</details>
+
+
+## Code
+<details>
+<summary>Code</summary>
+
+```py
+from graphql import GraphQLSchema, GraphQLField, GraphQLList, GraphQLObjectType, \
+    GraphQLInt, GraphQLString, GraphQLInputObjectType, GraphQLEnumType
+
+import frappe
+from frappe_graphql.utils.cursor_pagination import CursorPaginator
+
+
+def bind_todo_with_user_status_sorting(schema: GraphQLSchema):
+    schema.query_type.fields["get_todo_with_user_status_sorting"] = GraphQLField(
+
+        # Specify args, like first: 10
+        args=frappe._dict(
+            first=GraphQLInt,
+            after=GraphQLString,
+            last=GraphQLInt,
+            before=GraphQLString,
+
+            # The sortBy input type
+            sortBy=GraphQLInputObjectType(
+                name="TodoWithUserStatusSortingSortInfo",
+                fields=frappe._dict(
+                    direction=schema.type_map["SortDirection"],
+                    field=GraphQLEnumType(
+                        name="TodoWithUserStatusSortingSortField",
+                        values={
+                            "USER_AND_STATUS": ["owner", "status", "modified"],
+                            "USER_AND_MODIFIED": ["owner", "modified"]
+                        }
+                    )
+                )
+            )),
+
+        # resolve to CursorPaginator. Everything else will be taken care of
+        resolve=lambda obj, info, **kwargs: CursorPaginator(doctype="ToDo").resolve(
+            obj, info, **kwargs),
+
+        # The return type
+        type_=GraphQLObjectType(
+            "TodoWithUserStatusSorting",
+            frappe._dict(
+                totalCount=GraphQLInt,
+                pageInfo=schema.type_map["PageInfo"],
+                edges=GraphQLList(
+                    GraphQLObjectType(
+                        "TodoWithUserStatusSorting",
+                        frappe._dict(
+                            cursor=GraphQLString,
+                            node=schema.type_map["BaseDocType"])
+                    ))
+            )))
+
+```
+</details>

--- a/docs/pagination_examples/users_with_number_of_roles.md
+++ b/docs/pagination_examples/users_with_number_of_roles.md
@@ -1,0 +1,251 @@
+# Users with NumRoles
+In this example, sorting is done on an aggregated field, and conditions are applied in `HAVING` clause
+
+<details>
+<summary>Query</summary>
+
+```gql
+{
+    user_with_number_of_roles(first: 15, sortBy: { direction: DESC, field: NUM_ROLES }) {
+        totalCount
+        pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+        }
+        edges {
+            cursor
+            node {
+                full_name
+                num_roles
+                user {
+                    email,
+                    modified
+                }
+            }
+        }
+    }
+}
+```
+</details>
+
+<details>
+<summary>Response</summary>
+
+```json
+{
+    "data": {
+        "user_with_number_of_roles": {
+            "totalCount": 8,
+            "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "WwogMjUsCiAiQWRtaW5pc3RyYXRvciIKXQ==",
+                "endCursor": "WwogMSwKICJHdWVzdCIKXQ=="
+            },
+            "edges": [
+                {
+                    "cursor": "WwogMjUsCiAiQWRtaW5pc3RyYXRvciIKXQ==",
+                    "node": {
+                        "full_name": "Administrator",
+                        "num_roles": 25,
+                        "user": {
+                            "email": "admin@example.com",
+                            "modified": "2021-02-02 08:35:14.026077"
+                        }
+                    }
+                },
+                {
+                    "cursor": "WwogMjIsCiAiVGVzdCBBbGkgWmFpbiIKXQ==",
+                    "node": {
+                        "full_name": "Test User",
+                        "num_roles": 22,
+                        "user": {
+                            "email": "test_user@gmail.com",
+                            "modified": "2021-02-13 23:23:55.278023"
+                        }
+                    }
+                },
+                {
+                    "cursor": "WwogMjAsCiAiVCAzIgpd",
+                    "node": {
+                        "full_name": "T 3",
+                        "num_roles": 20,
+                        "user": {
+                            "email": "t3@t.com",
+                            "modified": "2021-04-17 03:05:16.303065"
+                        }
+                    }
+                },
+                {
+                    "cursor": "WwogNiwKICJUIDIiCl0=",
+                    "node": {
+                        "full_name": "T 2",
+                        "num_roles": 6,
+                        "user": {
+                            "email": "t2@t.com",
+                            "modified": "2021-04-17 03:32:21.515262"
+                        }
+                    }
+                },
+                {
+                    "cursor": "WwogNSwKICJUIDUiCl0=",
+                    "node": {
+                        "full_name": "T 5",
+                        "num_roles": 5,
+                        "user": {
+                            "email": "t5@t.com",
+                            "modified": "2021-04-17 03:33:20.008605"
+                        }
+                    }
+                },
+                {
+                    "cursor": "WwogMSwKICJUIDQiCl0=",
+                    "node": {
+                        "full_name": "T 4",
+                        "num_roles": 1,
+                        "user": {
+                            "email": "t4@t.com",
+                            "modified": "2021-04-05 08:32:48.494305"
+                        }
+                    }
+                },
+                {
+                    "cursor": "WwogMSwKICJUIDEiCl0=",
+                    "node": {
+                        "full_name": "T 1",
+                        "num_roles": 1,
+                        "user": {
+                            "email": "t1@t.com",
+                            "modified": "2021-04-05 08:32:03.416163"
+                        }
+                    }
+                },
+                {
+                    "cursor": "WwogMSwKICJHdWVzdCIKXQ==",
+                    "node": {
+                        "full_name": "Guest",
+                        "num_roles": 1,
+                        "user": {
+                            "email": "guest@example.com",
+                            "modified": "2021-04-06 19:59:00.394288"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+</details>
+
+<details>
+<summary>Code</summary>
+
+```py
+import graphql as gql
+
+import frappe
+from frappe_graphql.utils.cursor_pagination import CursorPaginator
+from graphql.type.definition import GraphQLObjectType
+from graphql.type.scalars import GraphQLInt, GraphQLString
+
+
+def bind_user_with_number_of_roles(schema: gql.GraphQLSchema):
+
+    def node_resolver(
+            paginator: CursorPaginator, filters=None, sorting_fields=[], sort_dir="asc", limit=5):
+
+        # When after OR before is specified, we expect a SINGLE filter
+        conditions = " HAVING {}".format(filters[0]) if len(filters) else ""
+        if conditions:
+            conditions = conditions.replace("`tabUser`.num_roles", "num_roles")
+            conditions = conditions.replace("`tabUser`.full_name", "full_name")
+
+        data = frappe.db.sql(f"""
+            SELECT
+                user.name,
+                'User' as doctype,
+                user.full_name,
+                COUNT(*) AS num_roles
+            FROM `tabUser` user
+            JOIN `tabHas Role` has_role
+                ON has_role.parent = user.name AND has_role.parenttype = "User"
+            GROUP BY has_role.parent
+            {conditions}
+            ORDER BY {", ".join([
+                f"{'user.' if x == 'modified' else ''}{x} {sort_dir}"
+                for x in sorting_fields
+            ])}
+            LIMIT {limit}
+        """, as_dict=1)
+
+        for r in data:
+            r.user = frappe._dict(doctype="User", name=r.name)
+
+        return data
+
+    def count_resolver(paginator: CursorPaginator, filters=None):
+        return frappe.db.count("User")
+
+    schema.query_type.fields["user_with_number_of_roles"] = gql.GraphQLField(
+
+        args=frappe._dict(
+            first=gql.GraphQLInt,
+            after=gql.GraphQLString,
+            last=gql.GraphQLInt,
+            before=gql.GraphQLString,
+            sortBy=gql.GraphQLArgument(
+                default_value={
+                    "direction": "DESC",
+                    "field": "NUM_ROLES"
+                },
+                type_=gql.GraphQLInputObjectType(
+                    name="UserWithNumRolesSortInfo",
+                    fields=frappe._dict(
+                        direction=schema.type_map["SortDirection"],
+                        field=gql.GraphQLEnumType(
+                            name="UserWithNumRolesSortField",
+                            values={
+                                "NUM_ROLES": ["num_roles", "full_name"],
+                                "NAME": ["full_name", "modified"]
+                            }
+                        )
+                    )
+                )
+            )
+        ),
+
+        # return type
+        type_=gql.GraphQLObjectType(
+            name="UserWithNumRolesConnection",
+            fields=frappe._dict(
+                totalCount=GraphQLInt,
+                pageInfo=schema.type_map["PageInfo"],
+                edges=gql.GraphQLList(gql.GraphQLObjectType(
+                    name="UserWithNumRolesNode",
+                    fields=frappe._dict(
+                        cursor=GraphQLString,
+                        node=GraphQLObjectType(
+                            name="UserWithNumRolesNodeDetails",
+                            fields=frappe._dict(
+                                num_roles=GraphQLInt,
+                                full_name=GraphQLString,
+                                user=schema.type_map["User"]
+                            )
+                        )
+                    )
+                ))
+            )
+        ),
+
+        resolve=lambda obj, info, **kwargs: CursorPaginator(
+            doctype="User",
+            node_resolver=node_resolver,
+            count_resolver=count_resolver
+        ).resolve(obj, info, **kwargs)
+    )
+
+```
+</details>

--- a/frappe_graphql/utils/cursor_pagination.py
+++ b/frappe_graphql/utils/cursor_pagination.py
@@ -181,8 +181,9 @@ class CursorPaginator(object):
         def format_column_name(column):
             if "." in column:
                 return column
-
-            return f"`tab{self.doctype}`.{column}"
+            meta = frappe.get_meta(self.doctype)
+            return f"`tab{self.doctype}`.{column}" if column in \
+                meta.get_valid_columns() else column
 
         def db_escape(v):
             return frappe.db.escape(v)


### PR DESCRIPTION
Now, an array of sort columns can be set to the sort fields. The sort field can be named to anything you like as long as you have a mapping done for the field enums.

Please check out the new examples added to the docs folder. Specifically the Users with num_roles example and its node_resolver.

Please merge #18 first