### PR TITLE
feat: Rollback + Full traceback for GraphQLErrors

### DIFF
--- a/frappe_graphql/api.py
+++ b/frappe_graphql/api.py
@@ -1,0 +1,113 @@
+from graphql import GraphQLError
+
+import frappe
+from .graphql import execute
+
+
+@frappe.whitelist(allow_guest=True)
+def execute_gql_query():
+    query, variables, operation_name = get_query()
+    output = execute(
+        query=query,
+        variables=variables,
+        operation_name=operation_name
+    )
+
+    frappe.local.response = output
+    if len(output.get("errors", [])):
+        frappe.db.rollback()
+        log_error(query, variables, operation_name, output)
+        frappe.local.response["http_status_code"] = 400
+
+
+def get_query():
+    """
+    Gets Query details as per the specs in https://graphql.org/learn/serving-over-http/
+    """
+
+    query = None
+    variables = None
+    operation_name = None
+    if not hasattr(frappe.local, "request"):
+        return query, variables, operation_name
+
+    from werkzeug.wrappers import Request
+    request: Request = frappe.local.request
+    content_type = request.content_type or ""
+
+    if request.method == "GET":
+        query = frappe.safe_decode(request.args["query"])
+        variables = frappe.safe_decode(request.args["variables"])
+        operation_name = frappe.safe_decode(request.args["operation_name"])
+    elif request.method == "POST":
+        # raise Exception("Please send in application/json")
+        if "application/json" in content_type:
+            graphql_request = frappe.parse_json(request.get_data(as_text=True))
+            query = graphql_request.query
+            variables = graphql_request.variables
+            operation_name = graphql_request.operationName
+
+        elif "multipart/form-data" in content_type:
+            # Follows the spec here: https://github.com/jaydenseric/graphql-multipart-request-spec
+            # This could be used for file uploads, single / multiple
+            operations = frappe.parse_json(request.form.get("operations"))
+            query = operations.get("query")
+            variables = operations.get("variables")
+            operation_name = operations.get("operationName")
+
+            files_map = frappe.parse_json(request.form.get("map"))
+            for file_key in files_map:
+                file_instances = files_map[file_key]
+                for file_instance in file_instances:
+                    path = file_instance.split(".")
+                    obj = operations[path.pop(0)]
+                    while len(path) > 1:
+                        obj = obj[path.pop(0)]
+
+                    obj[path.pop(0)] = file_key
+
+    return query, variables, operation_name
+
+
+def log_error(query, variables, operation_name, output):
+    import traceback as tb
+    tracebacks = []
+    for idx, err in enumerate(output.errors):
+        if not isinstance(err, GraphQLError):
+            continue
+
+        exc = err.original_error
+        if not exc:
+            continue
+        tracebacks.append(
+            f"GQLError #{idx}\n"
+            + f"{str(err)}\n\n"
+            + f"{''.join(tb.format_exception(exc, exc, exc.__traceback__))}"
+            + "==========================================\n\n"
+        )
+
+    if frappe.conf.get("developer_mode"):
+        frappe.errprint(f"frappe.get_traceback: {frappe.get_traceback()}")
+        frappe.errprint(tracebacks)
+
+    tracebacks = "\n\n".join(tracebacks)
+    frappe.log_error(
+        title="GraphQL API Error",
+        message=f"""
+Query: {query}
+Variables: {variables}
+Operation Name: {operation_name}
+
+Output:
+{output}
+
+Tracebacks:
+
+frappe.get_traceback():
+{frappe.get_traceback()}
+==========================================
+
+GraphQLError tracebacks:
+{tracebacks}
+"""
+    )

--- a/frappe_graphql/api.py
+++ b/frappe_graphql/api.py
@@ -4,6 +4,8 @@ from typing import List
 import frappe
 from .graphql import execute
 
+from .utils.variables import get_masked_variables
+
 
 @frappe.whitelist(allow_guest=True)
 def execute_gql_query():
@@ -112,7 +114,7 @@ def log_error(query, variables, operation_name, output):
         title="GraphQL API Error",
         operation_name=operation_name,
         query=query,
-        variables=frappe.as_json(variables) if variables else None,
+        variables=frappe.as_json(get_masked_variables(query, variables)) if variables else None,
         output=frappe.as_json(output),
         traceback=tracebacks
     ))

--- a/frappe_graphql/api.py
+++ b/frappe_graphql/api.py
@@ -4,7 +4,7 @@ from typing import List
 import frappe
 from .graphql import execute
 
-from .utils.variables import get_masked_variables
+from .utils.http import get_masked_variables, get_operation_name
 
 
 @frappe.whitelist(allow_guest=True)
@@ -112,7 +112,7 @@ def log_error(query, variables, operation_name, output):
     error_log = frappe.new_doc("GraphQL Error Log")
     error_log.update(frappe._dict(
         title="GraphQL API Error",
-        operation_name=operation_name,
+        operation_name=get_operation_name(query, operation_name),
         query=query,
         variables=frappe.as_json(get_masked_variables(query, variables)) if variables else None,
         output=frappe.as_json(output),

--- a/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.js
+++ b/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Leam Technology Systems and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('GraphQL Error Log', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.json
+++ b/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.json
@@ -6,9 +6,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "title",
-  "seen",
   "operation_name",
+  "seen",
   "query",
   "variables",
   "section_break_5",
@@ -16,12 +15,6 @@
   "traceback"
  ],
  "fields": [
-  {
-   "fieldname": "title",
-   "fieldtype": "Data",
-   "label": "Title",
-   "read_only": 1
-  },
   {
    "fieldname": "operation_name",
    "fieldtype": "Data",
@@ -66,9 +59,10 @@
    "read_only": 1
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-04-27 23:05:19.510053",
+ "modified": "2021-04-28 14:21:38.770483",
  "modified_by": "Administrator",
  "module": "Frappe Graphql",
  "name": "GraphQL Error Log",
@@ -88,5 +82,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "title_field": "operation_name"
 }

--- a/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.json
+++ b/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.json
@@ -1,0 +1,92 @@
+{
+ "actions": [],
+ "autoname": "GQL-ERR-.#####",
+ "creation": "2021-04-27 22:42:24.465758",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "seen",
+  "operation_name",
+  "query",
+  "variables",
+  "section_break_5",
+  "output",
+  "traceback"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "read_only": 1
+  },
+  {
+   "fieldname": "operation_name",
+   "fieldtype": "Data",
+   "label": "Operation Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "query",
+   "fieldtype": "Code",
+   "in_list_view": 1,
+   "label": "Query / Mutation",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "variables",
+   "fieldtype": "Code",
+   "label": "Variables",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_5",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "output",
+   "fieldtype": "Code",
+   "label": "Output",
+   "read_only": 1
+  },
+  {
+   "fieldname": "traceback",
+   "fieldtype": "Code",
+   "label": "Traceback",
+   "read_only": 1
+  },
+  {
+   "fieldname": "seen",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Seen",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2021-04-27 23:05:19.510053",
+ "modified_by": "Administrator",
+ "module": "Frappe Graphql",
+ "name": "GraphQL Error Log",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.py
+++ b/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Leam Technology Systems and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+import frappe
+from frappe.model.document import Document
+
+
+class GraphQLErrorLog(Document):
+    def onload(self):
+        if not self.seen:
+            self.db_set('seen', 1, update_modified=0)
+            frappe.db.commit()
+
+
+def set_old_logs_as_seen():
+    # set logs as seen
+    frappe.db.sql("""UPDATE `tabGraphQL Error Log` SET `seen`=1
+        WHERE `seen`=0 AND `creation` < (NOW() - INTERVAL '7' DAY)""")
+
+
+@frappe.whitelist()
+def clear_error_logs():
+    '''Flush all Error Logs'''
+    frappe.only_for('System Manager')
+    frappe.db.sql('''DELETE FROM `tabGraphQL Error Log`''')

--- a/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log_list.js
+++ b/frappe_graphql/frappe_graphql/doctype/graphql_error_log/graphql_error_log_list.js
@@ -1,0 +1,21 @@
+frappe.listview_settings['GraphQL Error Log'] = {
+	add_fields: ["seen"],
+	get_indicator: function(doc) {
+		if(cint(doc.seen)) {
+			return [__("Seen"), "green", "seen,=,1"];
+		} else {
+			return [__("Not Seen"), "red", "seen,=,0"];
+		}
+	},
+	order_by: "seen asc, modified desc",
+	onload: function(listview) {
+		listview.page.add_menu_item(__("Clear Logs"), function() {
+			frappe.call({
+				method:'frappe_graphql.frappe_graphql.doctype.graphql_error_log.graphql_error_log.clear_error_logs',
+				callback: function() {
+					listview.refresh();
+				}
+			});
+		});
+	}
+};

--- a/frappe_graphql/frappe_graphql/doctype/graphql_error_log/test_graphql_error_log.py
+++ b/frappe_graphql/frappe_graphql/doctype/graphql_error_log/test_graphql_error_log.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Leam Technology Systems and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+
+class TestGraphQLErrorLog(unittest.TestCase):
+    pass

--- a/frappe_graphql/frappe_graphql/types/root.graphql
+++ b/frappe_graphql/frappe_graphql/types/root.graphql
@@ -1,3 +1,6 @@
+scalar Upload
+scalar Password
+
 schema {
 	query: Query
 	mutation: Mutation
@@ -19,7 +22,6 @@ interface BaseDocType {
   modified_by__name: String!
 }
 
-scalar Upload
 
 type SET_VALUE_TYPE {
     doctype: String!

--- a/frappe_graphql/graphql.py
+++ b/frappe_graphql/graphql.py
@@ -7,11 +7,6 @@ from frappe_graphql.utils.resolver import default_field_resolver
 
 @frappe.whitelist(allow_guest=True)
 def execute(query=None, variables=None, operation_name=None):
-    query, variables, operation_name = get_query(
-        query=query,
-        variables=variables,
-        operation_name=operation_name
-    )
     result = graphql.graphql_sync(
         schema=get_schema(),
         source=query,
@@ -25,55 +20,4 @@ def execute(query=None, variables=None, operation_name=None):
             continue
         output[k] = getattr(result, k)
 
-    if hasattr(frappe.local, "request"):
-        frappe.local.response = output
-    else:
-        return output
-
-
-def get_query(query, variables, operation_name):
-    """
-    Gets Query details as per the specs in https://graphql.org/learn/serving-over-http/
-    """
-    if query:
-        return query, variables, operation_name
-
-    if not hasattr(frappe.local, "request"):
-        return query, variables, operation_name
-
-    from werkzeug.wrappers import Request
-    request: Request = frappe.local.request
-    content_type = request.content_type or ""
-
-    if request.method == "GET":
-        query = frappe.safe_decode(request.args["query"])
-        variables = frappe.safe_decode(request.args["variables"])
-        operation_name = frappe.safe_decode(request.args["operation_name"])
-    elif request.method == "POST":
-        # raise Exception("Please send in application/json")
-        if "application/json" in content_type:
-            graphql_request = frappe.parse_json(request.get_data(as_text=True))
-            query = graphql_request.query
-            variables = graphql_request.variables
-            operation_name = graphql_request.operationName
-
-        elif "multipart/form-data" in content_type:
-            # Follows the spec here: https://github.com/jaydenseric/graphql-multipart-request-spec
-            # This could be used for file uploads, single / multiple
-            operations = frappe.parse_json(request.form.get("operations"))
-            query = operations.get("query")
-            variables = operations.get("variables")
-            operation_name = operations.get("operationName")
-
-            files_map = frappe.parse_json(request.form.get("map"))
-            for file_key in files_map:
-                file_instances = files_map[file_key]
-                for file_instance in file_instances:
-                    path = file_instance.split(".")
-                    obj = operations[path.pop(0)]
-                    while len(path) > 1:
-                        obj = obj[path.pop(0)]
-
-                    obj[path.pop(0)] = file_key
-
-    return query, variables, operation_name
+    return output

--- a/frappe_graphql/hooks.py
+++ b/frappe_graphql/hooks.py
@@ -145,7 +145,7 @@ graphql_schema_processors = [
 # ------------------------------
 #
 override_whitelisted_methods = {
-    "graphql": "frappe_graphql.graphql.execute"
+    "graphql": "frappe_graphql.api.execute_gql_query"
 }
 #
 # each overriding function accepts a `data` argument;

--- a/frappe_graphql/utils/http.py
+++ b/frappe_graphql/utils/http.py
@@ -13,8 +13,8 @@ def get_masked_variables(query, variables):
     variables = frappe._dict(variables)
     try:
         document = parse(query)
-        for operation_definition in document.definitions:
-            for variable in operation_definition.variable_definitions:
+        for operation_definition in getattr(document, "definitions", []):
+            for variable in getattr(operation_definition, "variable_definitions", []):
                 variable_name = variable.variable.name.value
                 variable_type = variable.type
 

--- a/frappe_graphql/utils/http.py
+++ b/frappe_graphql/utils/http.py
@@ -29,7 +29,7 @@ def get_masked_variables(query, variables):
                     variable_type = variable_type.type
 
                 # Password is a named_type
-                if variable_type.kind != "named_type":
+                if variable_type.kind != "named_type" or not variable_type.name:
                     continue
 
                 if variable_type.name.value != "Password":
@@ -43,3 +43,36 @@ def get_masked_variables(query, variables):
         )
 
     return variables
+
+
+def get_operation_name(query, operation_name):
+    """
+    Gets the active operation name
+    if operation_name is not specified in the request,
+    it will take on the first operation definition if available.
+    Otherwise returns 'unnamed-query'
+    """
+    defined_operations = []
+    try:
+        document = parse(query)
+        print(document)
+        for operation_definition in document.definitions:
+            if operation_definition.kind != "operation_definition":
+                continue
+
+            # For non-named Queries
+            if not operation_definition.name:
+                continue
+
+            defined_operations.append(operation_definition.name.value)
+    except BaseException:
+        pass
+
+    if not operation_name and len(defined_operations):
+        return defined_operations[0]
+    elif operation_name in defined_operations:
+        return operation_name
+    elif operation_name:
+        return f"{operation_name} (invalid)"
+    else:
+        return "unnamed-query"

--- a/frappe_graphql/utils/http.py
+++ b/frappe_graphql/utils/http.py
@@ -55,7 +55,6 @@ def get_operation_name(query, operation_name):
     defined_operations = []
     try:
         document = parse(query)
-        print(document)
         for operation_definition in document.definitions:
             if operation_definition.kind != "operation_definition":
                 continue

--- a/frappe_graphql/utils/variables.py
+++ b/frappe_graphql/utils/variables.py
@@ -1,0 +1,45 @@
+from graphql import parse
+
+import frappe
+
+
+def get_masked_variables(query, variables):
+    """
+    Return the variables dict with password field set to "******"
+    """
+    if isinstance(variables, str):
+        variables = frappe.parse_json(variables)
+
+    variables = frappe._dict(variables)
+    try:
+        document = parse(query)
+        for operation_definition in document.definitions:
+            for variable in operation_definition.variable_definitions:
+                variable_name = variable.variable.name.value
+                variable_type = variable.type
+
+                if variable_name not in variables:
+                    continue
+
+                if not isinstance(variables[variable_name], str):
+                    continue
+
+                # Password! NonNull
+                if variable_type.kind == "non_null_type":
+                    variable_type = variable_type.type
+
+                # Password is a named_type
+                if variable_type.kind != "named_type":
+                    continue
+
+                if variable_type.name.value != "Password":
+                    continue
+
+                variables[variable_name] = "*" * len(variables[variable_name])
+    except BaseException:
+        return frappe._dict(
+            status="Error Processing Variable Definitions",
+            traceback=frappe.get_traceback()
+        )
+
+    return variables


### PR DESCRIPTION
The following is done if there is any error on graphql response:
- DB Rollback
- Make `GraphQL Error Log`
- Mask the incoming Password fields in `GraphQL Error Logs`
- Traceback in Response if `developer_mode`

<details><summary>Error Log Example</summary>

```
Query: {
    get_todo_with_user_status_sorting(first: 10) {
        totalCount
    }
    user_with_number_of_roles(first: 15, sortBy: { direction: DESC, field: NUM_ROLES }) {
        totalCount
        pageInfo {
            hasNextPage
            hasPreviousPage
            startCursor
            endCursor
        }
        edges {
            cursor
            node {
                full_name
                num_roles
                user {
                    email,
                    modified
                }
            }
        }
    }
}
Variables: None
Operation Name: None

Output:
{'data': {'get_todo_with_user_status_sorting': None, 'user_with_number_of_roles': None}, 'errors': [GraphQLError('RANDOM', locations=[SourceLocation(line=2, column=5)], path=['get_todo_with_user_status_sorting']), GraphQLError("'list' object has no attribute 'lower'", locations=[SourceLocation(line=5, column=5)], path=['user_with_number_of_roles'])]}

Tracebacks:

frappe.get_traceback():
NoneType: None

==========================================

GraphQLError tracebacks:
GQLError #0
RANDOM

GraphQL request:2:5
1 | {
2 |     get_todo_with_user_status_sorting(first: 10) {
  |     ^
3 |         totalCount

Traceback (most recent call last):
  File "/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py", line 679, in complete_value_catching_error
    return_type, field_nodes, info, path, result
  File "/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py", line 745, in complete_value
    raise result
  File "/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py", line 637, in resolve_field_value_or_error
    result = resolve_fn(source, info, **args)
  File "/home/faztp12/dev-bench/frappe-graphql/apps/test_app/test_app/todo_with_user_status_sorting.py", line 35, in <lambda>
    obj, info, **kwargs),
  File "/home/faztp12/dev-bench/frappe-graphql/apps/frappe_graphql/frappe_graphql/utils/cursor_pagination.py", line 87, in resolve
    raise Exception("RANDOM")
Exception: RANDOM
==========================================



GQLError #1
'list' object has no attribute 'lower'

GraphQL request:5:5
4 |     }
5 |     user_with_number_of_roles(first: 15, sortBy: { direction: DESC, field: NUM_ROLES }) {
  |     ^
6 |         totalCount

Traceback (most recent call last):
  File "/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py", line 679, in complete_value_catching_error
    return_type, field_nodes, info, path, result
  File "/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py", line 745, in complete_value
    raise result
  File "/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py", line 637, in resolve_field_value_or_error
    result = resolve_fn(source, info, **args)
  File "/home/faztp12/dev-bench/frappe-graphql/apps/test_app/test_app/user_with_number_of_roles.py", line 101, in <lambda>
    ).resolve(obj, info, **kwargs)
  File "/home/faztp12/dev-bench/frappe-graphql/apps/frappe_graphql/frappe_graphql/utils/cursor_pagination.py", line 43, in resolve
    sort_key, sort_dir = self.get_sort_args(kwargs.get("sortBy"))
  File "/home/faztp12/dev-bench/frappe-graphql/apps/frappe_graphql/frappe_graphql/utils/cursor_pagination.py", line 151, in get_sort_args
    sort_key = sorting_input.get("field").lower()
AttributeError: 'list' object has no attribute 'lower'
==========================================
```
</details>

<details><summary>Traceback in Response Example</summary>

```json
{
    "data": {
        "get_todo_with_user_status_sorting": null,
        "user_with_number_of_roles": null
    },
    "errors": [
        "GraphQLError('RANDOM', locations=[SourceLocation(line=2, column=5)], path=['get_todo_with_user_status_sorting'])",
        "GraphQLError(\"'list' object has no attribute 'lower'\", locations=[SourceLocation(line=5, column=5)], path=['user_with_number_of_roles'])"
    ],
    "exc": "[\"frappe.get_traceback: NoneType: None\\n\", \"['GQLError #0\\\\nRANDOM\\\\n\\\\nGraphQL request:2:5\\\\n1 | {\\\\n2 |     get_todo_with_user_status_sorting(first: 10) {\\\\n  |     ^\\\\n3 |         totalCount\\\\n\\\\nTraceback (most recent call last):\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py\\\", line 679, in complete_value_catching_error\\\\n    return_type, field_nodes, info, path, result\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py\\\", line 745, in complete_value\\\\n    raise result\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py\\\", line 637, in resolve_field_value_or_error\\\\n    result = resolve_fn(source, info, **args)\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/apps/test_app/test_app/todo_with_user_status_sorting.py\\\", line 35, in <lambda>\\\\n    obj, info, **kwargs),\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/apps/frappe_graphql/frappe_graphql/utils/cursor_pagination.py\\\", line 87, in resolve\\\\n    raise Exception(\\\"RANDOM\\\")\\\\nException: RANDOM\\\\n==========================================\\\\n\\\\n', 'GQLError #1\\\\n\\\\'list\\\\' object has no attribute \\\\'lower\\\\'\\\\n\\\\nGraphQL request:5:5\\\\n4 |     }\\\\n5 |     user_with_number_of_roles(first: 15, sortBy: { direction: DESC, field: NUM_ROLES }) {\\\\n  |     ^\\\\n6 |         totalCount\\\\n\\\\nTraceback (most recent call last):\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py\\\", line 679, in complete_value_catching_error\\\\n    return_type, field_nodes, info, path, result\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py\\\", line 745, in complete_value\\\\n    raise result\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.6/site-packages/graphql/execution/execute.py\\\", line 637, in resolve_field_value_or_error\\\\n    result = resolve_fn(source, info, **args)\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/apps/test_app/test_app/user_with_number_of_roles.py\\\", line 101, in <lambda>\\\\n    ).resolve(obj, info, **kwargs)\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/apps/frappe_graphql/frappe_graphql/utils/cursor_pagination.py\\\", line 43, in resolve\\\\n    sort_key, sort_dir = self.get_sort_args(kwargs.get(\\\"sortBy\\\"))\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/apps/frappe_graphql/frappe_graphql/utils/cursor_pagination.py\\\", line 151, in get_sort_args\\\\n    sort_key = sorting_input.get(\\\"field\\\").lower()\\\\nAttributeError: \\\\'list\\\\' object has no attribute \\\\'lower\\\\'\\\\n==========================================\\\\n\\\\n']\"]"
}
```
</details>