### PR TITLE
feat: SelectDocfields as GQL Enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ $ bench --site test_site graphql generate_sdl --output-dir <your-app/graphql> --
 # Generate sdls for doctype <d1> <2>
 $ bench --site test_site graphql generate_sdl --output-dir <your-app/graphql> --doctype <d1> -dt <d2> -dt <name>
 
+# Generate sdls for all doctypes in <your-app> without Enums for Select Fields
+$ bench --site test_site graphql generate_sdl --output-dir <your-app/graphql> --app <your-app> --disable-enum-select-fields
 ```
 - Specify this directory in `graphql_sdl_dir` hook and you are done.
 ### Introducing a Custom Field to GraphQL

--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -19,10 +19,12 @@ def graphql():
               help="Doctype to generate sdls for. You can specify multiple")
 @click.option("--ignore-custom-fields", is_flag=True, default=False,
               help="Ignore custom fields generation")
+@click.option("--disable-enum-select-fields", is_flag=True, default=False,
+              help="Disable generating GQLEnums for Frappe Select DocFields")
 @pass_context
 def generate_sdl(
     context, output_dir=None, app=None, module=None, doctype=None,
-    ignore_custom_fields=False
+    ignore_custom_fields=False, disable_enum_select_fields=False
 ):
     site = get_site(context=context)
     try:
@@ -31,7 +33,8 @@ def generate_sdl(
         target_dir = frappe.get_site_path("doctype_sdls")
         if output_dir:
             if not path.isabs(output_dir):
-                target_dir = path.abspath(path.join(getcwd(), "../apps", output_dir))
+                target_dir = path.abspath(
+                    path.join(getcwd(), "../apps", output_dir))
             else:
                 target_dir = output_dir
         target_dir = path.abspath(target_dir)
@@ -41,7 +44,8 @@ def generate_sdl(
             app=app,
             modules=list(module),
             doctypes=list(doctype),
-            ignore_custom_fields=ignore_custom_fields
+            ignore_custom_fields=ignore_custom_fields,
+            disable_enum_selectdf=disable_enum_select_fields
         )
     finally:
         frappe.destroy()

--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -45,7 +45,7 @@ def generate_sdl(
             modules=list(module),
             doctypes=list(doctype),
             ignore_custom_fields=ignore_custom_fields,
-            disable_enum_selectdf=disable_enum_select_fields
+            disable_enum_select_fields=disable_enum_select_fields
         )
     finally:
         frappe.destroy()

--- a/frappe_graphql/frappe_graphql/types/doctype.graphql
+++ b/frappe_graphql/frappe_graphql/types/doctype.graphql
@@ -6,13 +6,13 @@ type DocType implements BaseDocType {
   modified: String
   modified_by: User!
   parent: BaseDocType
-  parent__name: String
   parentfield: String
   parenttype: String
   idx: Int
   docstatus: Int
   owner__name: String!
   modified_by__name: String!
+  parent__name: String
   module: ModuleDef!
   module__name: String
   is_submittable: Int
@@ -28,7 +28,7 @@ type DocType implements BaseDocType {
   beta: Int
   fields: [DocField!]!
   autoname: String
-  name_case: String
+  name_case: DocTypeNameCaseSelectOptions
   description: String
   documentation: String
   image_field: String
@@ -45,8 +45,8 @@ type DocType implements BaseDocType {
   search_fields: String
   default_print_format: String
   sort_field: String
-  sort_order: String
-  document_type: String
+  sort_order: DocTypeDefaultSortOrderSelectOptions
+  document_type: DocTypeShowInModuleSectionSelectOptions
   icon: String
   color: String
   show_preview_popup: Int
@@ -66,7 +66,29 @@ type DocType implements BaseDocType {
   index_web_pages_for_search: Int
   route: String
   is_published_field: String
-  engine: String
+  engine: DocTypeDatabaseEngineSelectOptions
+}
+
+enum DocTypeNameCaseSelectOptions {
+  TITLE_CASE
+  UPPER_CASE
+}
+
+enum DocTypeDefaultSortOrderSelectOptions {
+  ASC
+  DESC
+}
+
+enum DocTypeShowInModuleSectionSelectOptions {
+  DOCUMENT
+  SETUP
+  SYSTEM
+  OTHER
+}
+
+enum DocTypeDatabaseEngineSelectOptions {
+  INNODB
+  MYISAM
 }
 
 enum DocTypeSortField {

--- a/frappe_graphql/utils/generate_sdl/__init__.py
+++ b/frappe_graphql/utils/generate_sdl/__init__.py
@@ -24,7 +24,7 @@ SDL_PREDEFINED_DOCTYPES = [
 
 
 def make_doctype_sdl_files(target_dir, app=None, modules=[], doctypes=[],
-                           ignore_custom_fields=False, disable_enum_selectdf=False):
+                           ignore_custom_fields=False, disable_enum_select_fields=False):
     specific_doctypes = doctypes or []
     doctypes = get_doctypes(
         app=app,
@@ -33,7 +33,7 @@ def make_doctype_sdl_files(target_dir, app=None, modules=[], doctypes=[],
     )
 
     options = frappe._dict(
-        disable_enum_selectdf=disable_enum_selectdf,
+        disable_enum_select_fields=disable_enum_select_fields,
         ignore_custom_fields=ignore_custom_fields
     )
 

--- a/frappe_graphql/utils/generate_sdl/__init__.py
+++ b/frappe_graphql/utils/generate_sdl/__init__.py
@@ -24,7 +24,7 @@ SDL_PREDEFINED_DOCTYPES = [
 
 
 def make_doctype_sdl_files(target_dir, app=None, modules=[], doctypes=[],
-                           ignore_custom_fields=False):
+                           ignore_custom_fields=False, disable_enum_selectdf=False):
     specific_doctypes = doctypes or []
     doctypes = get_doctypes(
         app=app,
@@ -32,11 +32,17 @@ def make_doctype_sdl_files(target_dir, app=None, modules=[], doctypes=[],
         doctypes=doctypes
     )
 
+    options = frappe._dict(
+        disable_enum_selectdf=disable_enum_selectdf,
+        ignore_custom_fields=ignore_custom_fields
+    )
+
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
 
     def write_file(filename, contents):
-        target_file = os.path.join(target_dir, f"{frappe.scrub(filename)}.graphql")
+        target_file = os.path.join(
+            target_dir, f"{frappe.scrub(filename)}.graphql")
         with open(target_file, "w") as f:
             f.write(contents)
 
@@ -44,7 +50,7 @@ def make_doctype_sdl_files(target_dir, app=None, modules=[], doctypes=[],
         if doctype not in specific_doctypes and \
                 (doctype in IGNORED_DOCTYPES or doctype in SDL_PREDEFINED_DOCTYPES):
             continue
-        sdl = get_doctype_sdl(doctype, ignore_custom_fields)
+        sdl = get_doctype_sdl(doctype=doctype, options=options)
         write_file(doctype, sdl)
 
 

--- a/frappe_graphql/utils/generate_sdl/doctype.py
+++ b/frappe_graphql/utils/generate_sdl/doctype.py
@@ -6,15 +6,22 @@ from frappe.model import default_fields, display_fieldtypes, table_fields
 from frappe.model.meta import Meta
 
 
-def get_doctype_sdl(doctype, ignore_custom_fields=False):
+def get_doctype_sdl(doctype, options):
+    """
+    options = dict(
+        disable_enum_selectdf=False,
+        ignore_custom_fields=False
+    )
+    """
     meta = frappe.get_meta(doctype)
-    sdl, defined_fieldnames = get_basic_doctype_sdl(meta)
+    sdl, defined_fieldnames = get_basic_doctype_sdl(meta, options=options)
 
     # Extend Doctype with Custom Fields
-    if not ignore_custom_fields and len(meta.get_custom_fields()):
+    if not options.ignore_custom_fields and len(meta.get_custom_fields()):
         sdl += get_custom_field_sdl(meta, defined_fieldnames)
 
-    sdl += get_select_docfield_enums(meta=meta, ignore_custom_fields=ignore_custom_fields)
+    if not options.disable_enum_selectdf:
+        sdl += get_select_docfield_enums(meta=meta, options=options)
 
     # DocTypeSortingInput
     if not meta.issingle:
@@ -27,7 +34,7 @@ def get_doctype_sdl(doctype, ignore_custom_fields=False):
     return sdl
 
 
-def get_basic_doctype_sdl(meta: Meta):
+def get_basic_doctype_sdl(meta: Meta, options: dict):
     dt = format_doctype(meta.name)
     sdl = f"type {dt} implements BaseDocType {{"
 
@@ -55,7 +62,7 @@ def get_basic_doctype_sdl(meta: Meta):
         if cint(field.get("is_custom_field")):
             continue
         defined_fieldnames.append(field.fieldname)
-        sdl += f"\n  {get_field_sdl(meta, field)}"
+        sdl += f"\n  {get_field_sdl(meta, field, options=options)}"
         if field.fieldtype in ("Link", "Dynamic Link"):
             sdl += f"\n  {get_link_field_name_sdl(field)}"
 
@@ -80,10 +87,10 @@ def get_custom_field_sdl(meta, defined_fieldnames):
     return sdl
 
 
-def get_select_docfield_enums(meta, ignore_custom_fields):
+def get_select_docfield_enums(meta, options):
     sdl = ""
     for field in meta.get("fields", {"fieldtype": "Select"}):
-        if ignore_custom_fields and cint(field.get("is_custom_field")):
+        if options.ignore_custom_fields and cint(field.get("is_custom_field")):
             continue
 
         sdl += "\n\n"
@@ -159,15 +166,15 @@ def get_query_type_extension(meta: Meta):
     return sdl
 
 
-def get_field_sdl(meta, docfield):
-    return f"{docfield.fieldname}: {get_graphql_type(meta, docfield)}"
+def get_field_sdl(meta, docfield, options: dict):
+    return f"{docfield.fieldname}: {get_graphql_type(meta, docfield, options=options)}"
 
 
 def get_link_field_name_sdl(docfield):
     return f"{docfield.fieldname}__name: String"
 
 
-def get_graphql_type(meta, docfield):
+def get_graphql_type(meta, docfield, options: dict):
     string_fieldtypes = [
         "Small Text", "Long Text", "Code", "Text Editor", "Markdown Editor", "HTML Editor",
         "Date", "Datetime", "Time", "Text", "Data", "Rating", "Read Only",
@@ -175,6 +182,9 @@ def get_graphql_type(meta, docfield):
     ]
     int_fieldtypes = ["Int", "Long Int", "Check"]
     float_fieldtypes = ["Currency", "Float", "Percent"]
+
+    if options.disable_enum_selectdf:
+        string_fieldtypes.append("Select")
 
     graphql_type = None
     if docfield.fieldtype in string_fieldtypes:
@@ -195,9 +205,11 @@ def get_graphql_type(meta, docfield):
         graphql_type = get_select_docfield_enum_name(meta.name, docfield)
 
         # Mark NonNull if there is no empty option and is required
-        has_empty_option = any([len(x or "") == 0 for x in (docfield.options or "").split("\n")])
+        has_empty_option = any(
+            [len(x or "") == 0 for x in (docfield.options or "").split("\n")])
         if docfield.reqd and has_empty_option:
-            frappe.throw("Please fix your HEAD on select field: {}".format(docfield.name))
+            frappe.throw(
+                "Please fix your HEAD on select field: {}".format(docfield.name))
         if docfield.reqd and not has_empty_option:
             graphql_type += "!"
     else:

--- a/frappe_graphql/utils/generate_sdl/doctype.py
+++ b/frappe_graphql/utils/generate_sdl/doctype.py
@@ -9,7 +9,7 @@ from frappe.model.meta import Meta
 def get_doctype_sdl(doctype, options):
     """
     options = dict(
-        disable_enum_selectdf=False,
+        disable_enum_select_fields=False,
         ignore_custom_fields=False
     )
     """
@@ -20,7 +20,7 @@ def get_doctype_sdl(doctype, options):
     if not options.ignore_custom_fields and len(meta.get_custom_fields()):
         sdl += get_custom_field_sdl(meta, defined_fieldnames)
 
-    if not options.disable_enum_selectdf:
+    if not options.disable_enum_select_fields:
         sdl += get_select_docfield_enums(meta=meta, options=options)
 
     # DocTypeSortingInput
@@ -183,7 +183,7 @@ def get_graphql_type(meta, docfield, options: dict):
     int_fieldtypes = ["Int", "Long Int", "Check"]
     float_fieldtypes = ["Currency", "Float", "Percent"]
 
-    if options.disable_enum_selectdf:
+    if options.disable_enum_select_fields:
         string_fieldtypes.append("Select")
 
     graphql_type = None

--- a/frappe_graphql/utils/generate_sdl/doctype.py
+++ b/frappe_graphql/utils/generate_sdl/doctype.py
@@ -18,7 +18,7 @@ def get_doctype_sdl(doctype, options):
 
     # Extend Doctype with Custom Fields
     if not options.ignore_custom_fields and len(meta.get_custom_fields()):
-        sdl += get_custom_field_sdl(meta, defined_fieldnames)
+        sdl += get_custom_field_sdl(meta, defined_fieldnames, options=options)
 
     if not options.disable_enum_select_fields:
         sdl += get_select_docfield_enums(meta=meta, options=options)
@@ -71,7 +71,7 @@ def get_basic_doctype_sdl(meta: Meta, options: dict):
     return sdl, defined_fieldnames
 
 
-def get_custom_field_sdl(meta, defined_fieldnames):
+def get_custom_field_sdl(meta, defined_fieldnames, options):
     sdl = f"\n\nextend type {format_doctype(meta.name)} {{"
     for field in meta.get_custom_fields():
         if field.fieldtype in display_fieldtypes:
@@ -79,7 +79,7 @@ def get_custom_field_sdl(meta, defined_fieldnames):
         if field.fieldname in defined_fieldnames:
             continue
         defined_fieldnames.append(field.fieldname)
-        sdl += f"\n  {get_field_sdl(meta, field)}"
+        sdl += f"\n  {get_field_sdl(meta, field, options=options)}"
         if field.fieldtype in ("Link", "Dynamic Link"):
             sdl += f"\n  {get_link_field_name_sdl(field)}"
     sdl += "\n}"

--- a/frappe_graphql/utils/resolver/document_resolver.py
+++ b/frappe_graphql/utils/resolver/document_resolver.py
@@ -55,14 +55,18 @@ def document_resolver(obj, info: GraphQLResolveInfo, **kwargs):
     if info.field_name.endswith("__name"):
         fieldname = info.field_name.split("__name")[0]
         return _get_value(fieldname)
-    elif df and df.fieldtype in ("Link", "Dynamic Link"):
-        if not _get_value(df.fieldname):
-            return None
-        link_dt = df.options if df.fieldtype == "Link" else \
-            _get_value(df.options)
-        return frappe._dict(name=_get_value(df.fieldname), doctype=link_dt)
-    else:
-        return _get_value(info.field_name)
+    elif df:
+        if df.fieldtype in ("Link", "Dynamic Link"):
+            if not _get_value(df.fieldname):
+                return None
+            link_dt = df.options if df.fieldtype == "Link" else \
+                _get_value(df.options)
+            return frappe._dict(name=_get_value(df.fieldname), doctype=link_dt)
+        elif df.fieldtype == "Select":
+            value = _get_value(df.fieldname) or ""
+            return frappe.scrub(value).upper()
+
+    return _get_value(info.field_name)
 
 
 def get_default_field_df(fieldname):


### PR DESCRIPTION
- Updated generate_sdl to make enum types for select docfield options
- Updated document resolver to return select values scrubbed and capitalized
- Updated DocType.graphql since that was the only core doctype that had Select fields in them.

Fixes #23 