### PR TITLE
fix: Handle Queries that requests docs that do not exists

### DIFF
--- a/frappe_graphql/utils/resolver/__init__.py
+++ b/frappe_graphql/utils/resolver/__init__.py
@@ -22,6 +22,9 @@ def default_field_resolver(obj: Any, info: GraphQLResolveInfo, **kwargs):
         if dt:
             if is_single(dt):
                 kwargs["name"] = dt
+            elif not frappe.db.exists(dt, kwargs.get("name")):
+                raise frappe.DoesNotExistError(
+                    frappe._("{0} {1} not found").format(frappe._(dt), kwargs.get("name")))
             return frappe._dict(
                 doctype=dt,
                 name=kwargs.get("name")


### PR DESCRIPTION
<details><summary>Before</summary>

Query
```gql
query {
  User(name: "Admin") {
    full_name
    email
  }
}
```

Response
```json
{
  "errors": [
    "GraphQLError('Cannot return null for non-nullable field User.email.', locations=[SourceLocation(line=4, column=5)], path=['User', 'email'])"
  ],
  "exc": "[\"['GQLError #0\\\\nCannot return null for non-nullable field User.email.\\\\n\\\\nGraphQL request:4:5\\\\n3 |     full_name\\\\n4 |     email\\\\n  |     ^\\\\n5 |   }\\\\n\\\\nTraceback (most recent call last):\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.7/site-packages/graphql/execution/execute.py\\\", line 679, in complete_value_catching_error\\\\n    return_type, field_nodes, info, path, result\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.7/site-packages/graphql/execution/execute.py\\\", line 759, in complete_value\\\\n    \\\"Cannot return null for non-nullable field\\\"\\\\nTypeError: Cannot return null for non-nullable field User.email.\\\\n', 'Frappe Traceback: \\\\nNoneType: None\\\\n']\"]"
}
```
</details>

<details><summary>After</summary>

Query
```gql
query {
  User(name: "Admin") {
    full_name
    email
  }
}
```

Response
```json
{
  "errors": [
    "GraphQLError(\"'Admin' in doctype 'User' do not exist\", locations=[SourceLocation(line=2, column=3)], path=['User'])"
  ],
  "exc": "[\"['GQLError #0\\\\n\\\\'Admin\\\\' in doctype \\\\'User\\\\' do not exist\\\\n\\\\nGraphQL request:2:3\\\\n1 | query {\\\\n2 |   User(name: \\\"Admin\\\") {\\\\n  |   ^\\\\n3 |     full_name\\\\n\\\\nTraceback (most recent call last):\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.7/site-packages/graphql/execution/execute.py\\\", line 679, in complete_value_catching_error\\\\n    return_type, field_nodes, info, path, result\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.7/site-packages/graphql/execution/execute.py\\\", line 745, in complete_value\\\\n    raise result\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/env/lib/python3.7/site-packages/graphql/execution/execute.py\\\", line 637, in resolve_field_value_or_error\\\\n    result = resolve_fn(source, info, **args)\\\\n  File \\\"/home/faztp12/dev-bench/frappe-graphql/apps/frappe_graphql/frappe_graphql/utils/resolver/__init__.py\\\", line 27, in default_field_resolver\\\\n    \\\"\\\\'{}\\\\' in doctype \\\\'{}\\\\' do not exist\\\".format(kwargs.get(\\\"name\\\"), dt))\\\\nfrappe.exceptions.DoesNotExistError: \\\\'Admin\\\\' in doctype \\\\'User\\\\' do not exist\\\\n', 'Frappe Traceback: \\\\nNoneType: None\\\\n']\"]"
}
```
</details>