### PR TITLE
fix: Prefix 'A' & 'An' for doctypes with equal plural form

### DIFF
--- a/frappe_graphql/utils/generate_sdl/doctype.py
+++ b/frappe_graphql/utils/generate_sdl/doctype.py
@@ -122,7 +122,11 @@ def get_query_type_extension(meta: Meta):
     else:
         plural = get_plural(meta.name)
         if plural == meta.name:
-            sdl += f"\n  A{dt}(name: String!): {dt}!"
+            prefix = "A"
+            if dt[0].lower() in ("a", "e", "i", "o", "u"):
+                prefix = "An"
+
+            sdl += f"\n  {prefix}{dt}(name: String!): {dt}!"
         else:
             sdl += f"\n  {dt}(name: String!): {dt}!"
 

--- a/frappe_graphql/utils/generate_sdl/doctype.py
+++ b/frappe_graphql/utils/generate_sdl/doctype.py
@@ -120,9 +120,13 @@ def get_query_type_extension(meta: Meta):
     if meta.issingle:
         sdl += f"\n  {dt}: {dt}!"
     else:
-        sdl += f"\n  {dt}(name: String!): {dt}!"
+        plural = get_plural(meta.name)
+        if plural == meta.name:
+            sdl += f"\n  A{dt}(name: String!): {dt}!"
+        else:
+            sdl += f"\n  {dt}(name: String!): {dt}!"
 
-        plural_dt = get_plural(meta.name)
+        plural_dt = format_doctype(plural)
         sdl += f"\n  {plural_dt}(filter: [DBFilterInput], sortBy: {dt}SortingInput, "
         sdl += "before: String, after: String, "
         sdl += f"first: Int, last: Int): {dt}CountableConnection!"
@@ -174,8 +178,7 @@ def get_graphql_type(docfield):
 
 def get_plural(doctype):
     p = inflect.engine()
-    pl = p.plural(doctype)
-    return format_doctype(pl)
+    return p.plural(doctype)
 
 
 def format_doctype(doctype):

--- a/frappe_graphql/utils/resolver/utils.py
+++ b/frappe_graphql/utils/resolver/utils.py
@@ -7,10 +7,18 @@ PLURAL_DOCTYPE_MAP_REDIS_KEY = "plural_doctype_graphql_map"
 def get_singular_doctype(name):
     singular_map = frappe.cache().get_value(SINGULAR_DOCTYPE_MAP_REDIS_KEY)
     if not singular_map:
+        import inflect
+        p = inflect.engine()
+
         valid_doctypes = [x.name for x in frappe.get_all("DocType")]
         singular_map = frappe._dict()
         for dt in valid_doctypes:
-            singular_map[dt.replace(" ", "")] = dt
+
+            # IF plural = singular, lets add a prefix: 'A'
+            if p.plural(dt) == dt:
+                singular_map[f"A{dt.replace(' ', '')}"] = dt
+            else:
+                singular_map[dt.replace(" ", "")] = dt
 
         frappe.cache().set_value(SINGULAR_DOCTYPE_MAP_REDIS_KEY, singular_map)
 

--- a/frappe_graphql/utils/resolver/utils.py
+++ b/frappe_graphql/utils/resolver/utils.py
@@ -16,7 +16,11 @@ def get_singular_doctype(name):
 
             # IF plural = singular, lets add a prefix: 'A'
             if p.plural(dt) == dt:
-                singular_map[f"A{dt.replace(' ', '')}"] = dt
+                prefix = "A"
+                if dt[0].lower() in ("a", "e", "i", "o", "u"):
+                    prefix = "An"
+
+                singular_map[f"{prefix}{dt.replace(' ', '')}"] = dt
             else:
                 singular_map[dt.replace(" ", "")] = dt
 


### PR DESCRIPTION
For those doctypes where `plural(doctype) == doctype`
As a solution, we prefix `A` to the singular form.

eg: Book Series
```gql
query {
  ABookSeries(name: String)
  BookSeries(first: 10)
}
```