### PR TITLE
feat: added generate_resolvers command

### DIFF
--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -174,8 +174,10 @@ def generate_resolvers(context, app=None, module=None, doctype=None, only_folder
         #     print(valid_path)
 
         extension_file_paths = []
-        # If doctypes given, only check for those doctypes; otherwise include all files ending in _extension.graphql
-        if len(given_doctypes) != 0:
+        # If doctypes given, only check for those doctypes; 
+        # if --only-folder is true, skip all checks
+        # otherwise include all files ending in _extension.graphql
+        if len(given_doctypes) != 0 and not only_folders:
 
             '''DEBUG PRINT'''
             # print("Got doctype option(s):", given_doctypes)

--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -1,6 +1,9 @@
 from os import getcwd, path
+from os import listdir
+from os.path import isfile, join
 import click
 import frappe
+from frappe_graphql.utils.generate_resolvers import make_extension_dirs
 from frappe_graphql.utils.generate_sdl import make_doctype_sdl_files
 from frappe.commands import pass_context, get_site
 
@@ -48,4 +51,177 @@ def generate_sdl(
 
 
 graphql.add_command(generate_sdl)
+
+
+# TODO: Option to generate folder strcutres for a manually typed, custom doctype (even if _extension doesn't exist)
+# TODO: Option to add controller dirs based on queries and mutations; can start by adding them as comments
+# TODO: Consider skipping an _extension file if it doesn't have queries/mutations in it
+@click.command("generate_resolvers")
+@click.option("--app", "-ap", help="All _extensions in the app will have bindings generated.")
+@click.option("--module", "-m", multiple=True, help="All _extensions in the modules(s) will have bindings generated.")
+@click.option("--doctype", "-dt", multiple=True, help="Specify exact doctype(s) to generate binding for.")
+@click.option("--only-folders", is_flag=True, default=False, help="Only generate the folders (No function files)")
+@pass_context
+def generate_resolvers(context, app=None, module=None, doctype=None, only_folders=False):
+    '''
+    Will generate /doc_type/reslovers/queries&mutations folder structure for every app in the site
+
+    If app is defined, it will restrict to that app. If modules are given, it will be restricted to 
+    only doctypes in those modules. Doctype names can be given to restrict to those doctypes specifically.
+    Only one type (app/module/doctype) is allowed in one command.
+    '''
+
+    given_app = app
+    given_modules = list(module)
+    given_doctypes = list(doctype)
+
+    type_option_count = 0
+    if given_app:
+        type_option_count += 1
+    if len(given_modules) > 0:
+        type_option_count += 1
+    if len(given_doctypes) > 0:
+        type_option_count += 1
+
+    if type_option_count > 1:
+        print("Can only specify one type (app or modules or doctypes). Exiting...")
+        exit()
+
+    module_paths = []
+
+    site = get_site(context=context)
+    try:
+        frappe.init(site=site)
+        frappe.connect()
+
+        site_apps = frappe.get_installed_apps()
+
+        if site_apps == []:
+            print('No apps installed on this site. Exiting...')
+            exit()
+
+        '''DEBUG PRINT'''
+        # print("installed apps:", frappe.get_installed_apps())
+
+        # If app option was given
+        if given_app:
+            if given_app not in site_apps:
+                print(
+                    f'No app named {given_app} installed on this site. Exiting...')
+                exit()
+            selected_apps = [given_app]
+        else:
+            selected_apps = site_apps
+
+        # If module option was given, try to find the module in the apps, otherwise find all modules in apps
+        if len(given_modules) != 0:
+
+            '''DEBUG PRINT'''
+            # print("Got module option(s):", given_modules)
+
+            for given_module in given_modules:
+
+                # To check if any module was found
+                number_of_module_paths = len(module_paths)
+
+                for selected_app in selected_apps:
+                    if given_module in frappe.get_module_list(selected_app):
+
+                        if frappe.scrub(given_module) == selected_app:
+                            # If module name is same as app, use the app root folder (because of convention)
+                            module_paths.append(
+                                path.join(frappe.get_app_path(selected_app)))
+                        else:
+                            module_paths.append(
+                                frappe.get_module_path(given_module))
+
+                if len(module_paths) == number_of_module_paths:
+                    print(
+                        f'No module named {given_module} found in any apps. Exiting...')
+                    exit()
+        else:
+            for selected_app in selected_apps:
+                app_modules = frappe.get_module_list(selected_app)
+                for app_module in app_modules:
+
+                    if frappe.scrub(app_module) == selected_app:
+                        # If module name is same as app, use the app root folder (because of convention)
+                        module_paths.append(
+                            path.join(frappe.get_app_path(selected_app)))
+                    else:
+                        module_paths.append(frappe.get_module_path(app_module))
+
+        '''DEBUG PRINT'''
+        # print("All filtered module paths:")
+
+        # Prune the modules so only relevant modules are left i.e: module paths with graphql/types folders in them
+        valid_paths = []
+        for module_path in module_paths:
+            types_path = path.join(module_path, 'graphql/types')
+
+            '''DEBUG PRINT'''
+            # print("path: ", types_path)
+
+            if path.exists(types_path):
+                valid_paths.append(types_path)
+
+                '''DEBUG PRINT'''
+                # print("Valid path: ", types_path)
+
+        '''DEBUG PRINT'''
+        # print("All valid paths:")
+        # for valid_path in valid_paths:
+        #     print(valid_path)
+
+        extension_file_paths = []
+        # If doctypes given, only check for those doctypes; otherwise include all files ending in _extension.graphql
+        if len(given_doctypes) != 0:
+
+            '''DEBUG PRINT'''
+            # print("Got doctype option(s):", given_doctypes)
+
+            for i in given_doctypes:
+                given_doctypes.append(frappe.scrub(
+                    given_doctypes.pop() + "_extension.graphql"))
+
+            '''DEBUG PRINT'''
+            # print(given_doctypes)
+
+            # For all files in all valid_paths, return the path+filename if:
+            # 1. It's a file (listdir also lists the directories)
+            # 2. It's one of the given doctypes
+            # 3. It has _extension in its name
+            for valid_path in valid_paths:
+                extension_file_paths.extend([path.join(valid_path, name)
+                                             for name in listdir(valid_path)
+                                             if (isfile(join(valid_path, name))
+                                                 and (name in given_doctypes)
+                                                 and ("_extension" in name)
+                                                 )
+                                             ])
+        else:
+            for valid_path in valid_paths:
+                extension_file_paths.extend([path.join(valid_path, name)
+                                             for name in listdir(valid_path)
+                                             if (isfile(join(valid_path, name))
+                                                 and ("_extension" in name)
+                                                 )
+                                             ])
+
+        '''DEBUG PRINT'''
+        # print("All final files to operate on:")
+        # for file in extension_file_paths:
+        #     print(file)
+
+        if extension_file_paths == []:
+            print("Found no _extension files to operate on. Exiting...")
+            exit()
+
+        make_extension_dirs(extension_file_paths, only_folders)
+
+    finally:
+        frappe.destroy()
+
+
+graphql.add_command(generate_resolvers)
 commands = [graphql]

--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -57,9 +57,10 @@ def generate_sdl(
 graphql.add_command(generate_sdl)
 
 
-# TODO: Option to generate folder strcutres for a manually typed, custom doctype (even if _extension doesn't exist)
-# TODO: Option to add controller dirs based on queries and mutations; can start by adding them as comments
-# TODO: Consider skipping an _extension file if it doesn't have queries/mutations in it
+# Need to come up with a template system. A config file maybe? Or maybe just variables defined in the hooks.py file
+# Either way, need to argument-ize some of these variables and expose them.
+# Need to figure out which ones; how can generating resolvers be customized?
+
 @click.command("generate_resolvers")
 @click.option("--app", "-ap", help="All _extensions in the app will have bindings generated.")
 @click.option("--module", "-m", multiple=True, help="All _extensions in the modules(s) will have bindings generated.")
@@ -110,8 +111,7 @@ def generate_resolvers(context, app=None, module=None, doctype=None, only_folder
         # If app option was given
         if given_app:
             if given_app not in site_apps:
-                print(
-                    f'No app named {given_app} installed on this site. Exiting...')
+                print(f'No app named {given_app} installed on this site. Exiting...')
                 exit()
             selected_apps = [given_app]
         else:
@@ -133,25 +133,22 @@ def generate_resolvers(context, app=None, module=None, doctype=None, only_folder
 
                         if frappe.scrub(given_module) == selected_app:
                             # If module name is same as app, use the app root folder (because of convention)
-                            module_paths.append(
-                                path.join(frappe.get_app_path(selected_app)))
+                            module_paths.append(path.join(frappe.get_app_path(selected_app)))
                         else:
-                            module_paths.append(
-                                frappe.get_module_path(given_module))
+                            module_paths.append(frappe.get_module_path(given_module))
 
                 if len(module_paths) == number_of_module_paths:
-                    print(
-                        f'No module named {given_module} found in any apps. Exiting...')
+                    print(f'No module named {given_module} found in any apps. Exiting...')
                     exit()
         else:
             for selected_app in selected_apps:
+
                 app_modules = frappe.get_module_list(selected_app)
                 for app_module in app_modules:
 
                     if frappe.scrub(app_module) == selected_app:
                         # If module name is same as app, use the app root folder (because of convention)
-                        module_paths.append(
-                            path.join(frappe.get_app_path(selected_app)))
+                        module_paths.append(path.join(frappe.get_app_path(selected_app)))
                     else:
                         module_paths.append(frappe.get_module_path(app_module))
 
@@ -178,7 +175,7 @@ def generate_resolvers(context, app=None, module=None, doctype=None, only_folder
         #     print(valid_path)
 
         extension_file_paths = []
-        # If doctypes given, only check for those doctypes; 
+        # If doctypes given, only check for those doctypes;
         # if --only-folder is true, skip all checks
         # otherwise include all files ending in _extension.graphql
         if len(given_doctypes) != 0 and not only_folders:
@@ -198,21 +195,22 @@ def generate_resolvers(context, app=None, module=None, doctype=None, only_folder
             # 2. It's one of the given doctypes
             # 3. It has _extension in its name
             for valid_path in valid_paths:
-                extension_file_paths.extend([path.join(valid_path, name)
-                                             for name in listdir(valid_path)
-                                             if (isfile(join(valid_path, name))
-                                                 and (name in given_doctypes)
-                                                 and ("_extension" in name)
-                                                 )
-                                             ])
+                extension_file_paths.extend([
+                    path.join(valid_path, name)
+                    for name in listdir(valid_path)
+                    if (
+                        isfile(join(valid_path, name)) and
+                        (name in given_doctypes) and
+                        ("_extension" in name)
+                    )
+                ])
         else:
             for valid_path in valid_paths:
-                extension_file_paths.extend([path.join(valid_path, name)
-                                             for name in listdir(valid_path)
-                                             if (isfile(join(valid_path, name))
-                                                 and ("_extension" in name)
-                                                 )
-                                             ])
+                extension_file_paths.extend([
+                    path.join(valid_path, name)
+                    for name in listdir(valid_path)
+                    if (isfile(join(valid_path, name)) and ("_extension" in name))
+                ])
 
         '''DEBUG PRINT'''
         # print("All final files to operate on:")

--- a/frappe_graphql/utils/file.py
+++ b/frappe_graphql/utils/file.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.utils import cint
 from frappe.handler import ALLOWED_MIMETYPES
+import os
 
 
 def make_file_document(
@@ -31,7 +32,8 @@ def make_file_document(
         import mimetypes
         filetype = mimetypes.guess_type(filename)[0]
         if filetype not in ALLOWED_MIMETYPES:
-            frappe.throw(frappe._("You can only upload JPG, PNG, PDF, or Microsoft documents."))
+            frappe.throw(
+                frappe._("You can only upload JPG, PNG, PDF, or Microsoft documents."))
 
     ret = frappe.get_doc({
         "doctype": "File",
@@ -44,3 +46,49 @@ def make_file_document(
     })
     ret.save(ignore_permissions=ignore_permissions)
     return ret
+
+
+def make_dir_safe(path_to_dir_file):
+    """
+    Will make a dir, but only if doesn't already exist. Returns created path.
+    Expects absolute path.
+
+    """
+
+    if os.path.exists(path_to_dir_file):
+
+        '''DEBUG PRINT'''
+        # print("Directory already exists:", path_to_dir_file)
+
+        pass
+    else:
+
+        '''DEBUG PRINT'''
+        # print("Making dir...", path_to_dir_file)
+
+        os.mkdir(path_to_dir_file)
+
+    return path_to_dir_file
+
+
+def make_file(path_to_file, contents):
+    """
+    Will make a file with contents. Returns created path.
+    Expects absolute path.
+
+    Parameters
+    ----------
+    path_to_file: str
+        Full, absolute path to file
+    contents: str
+        What will be written in the file
+    """
+
+    '''DEBUG PRINT'''
+    # print("Writing file...", path_to_file)
+
+    file = open(path_to_file, "w")
+    file.write(contents)
+    file.close
+
+    return path_to_file

--- a/frappe_graphql/utils/generate_resolvers/__init__.py
+++ b/frappe_graphql/utils/generate_resolvers/__init__.py
@@ -1,0 +1,83 @@
+import os
+
+from frappe_graphql.utils.file import make_dir_safe, make_file
+from frappe_graphql.utils.generate_resolvers.resolvers import edit_hooks_file, generate_functions, generate_schema_content, scan_extension_for_functions
+
+def make_extension_dirs(paths, only_folders):
+    '''
+    Will make directories for all _extension file paths passed in.
+    Expects absolute paths.
+    '''
+
+    hooks_edited = False
+
+    # overall loop to deal with every path:
+    for file_path in paths:
+
+    # '''DEBUG'''
+    #file_path = paths[0]
+    # if True:
+        doctype_name = os.path.split(file_path)[1].split("_extension")[0]
+        graphql_path = os.path.split(os.path.split(file_path)[0])[0]
+        up_root_path, root_name = os.path.split(os.path.split(graphql_path)[0])
+
+        '''DEBUG PRINT'''
+        # print(root_name)
+
+        # Make base directory for doctype
+        doctype_root_path = make_dir_safe(
+            os.path.join(graphql_path, doctype_name+"/"))
+
+        schema_content = ""
+
+        if not only_folders:
+
+            queries, mutations = scan_extension_for_functions(file_path)
+
+            if queries != [] or mutations != []:
+                schema_content = generate_schema_content(
+                    queries, mutations, root_name, doctype_name)
+
+        # Inside, make the resolvers dir, and pop down a schema.py and __init__.py file
+        make_file(os.path.join(doctype_root_path, "__init__.py"), "")
+        make_file(os.path.join(doctype_root_path,
+                               "schema.py"), schema_content)
+        resolver_root_path = make_dir_safe(
+            os.path.join(doctype_root_path, "resolvers/"))
+
+        # Inside, make the queries and mutations dir, popping down another __init__.py file
+        make_file(os.path.join(resolver_root_path, "__init__.py"),
+                  "from .queries import *\nfrom .mutations import *")
+        query_root_path = make_dir_safe(
+            os.path.join(resolver_root_path, "queries/"))
+        mutation_root_path = make_dir_safe(
+            os.path.join(resolver_root_path, "mutations/"))
+
+        # Inside both, pop down __init__.py files...
+        make_file(os.path.join(query_root_path, "__init__.py"), "")
+        make_file(os.path.join(mutation_root_path, "__init__.py"), "")
+
+        #...and decide if you want to genertate files
+        if not only_folders:
+
+            binding_types = []
+
+            if queries != []:
+                generate_functions(queries, query_root_path)
+                binding_types.append("queries")
+
+            if mutations != []:
+                generate_functions(mutations, mutation_root_path)
+                binding_types.append("mutations")
+
+            edited = edit_hooks_file(os.path.join(up_root_path, root_name),
+                            doctype_name, binding_types)
+
+            if edited:
+                hooks_edited = True
+
+    if hooks_edited:
+        print("Successfully edited hooks.py")
+    else:
+        print("No changes made to hooks.py")
+

--- a/frappe_graphql/utils/generate_resolvers/__init__.py
+++ b/frappe_graphql/utils/generate_resolvers/__init__.py
@@ -1,7 +1,7 @@
 import os
-
 from frappe_graphql.utils.file import make_dir_safe, make_file
 from frappe_graphql.utils.generate_resolvers.resolvers import edit_hooks_file, generate_functions, generate_schema_content, scan_extension_for_functions
+
 
 def make_extension_dirs(paths, only_folders):
     '''
@@ -15,7 +15,7 @@ def make_extension_dirs(paths, only_folders):
     for file_path in paths:
 
     # '''DEBUG'''
-    #file_path = paths[0]
+    # file_path = paths[0]
     # if True:
         doctype_name = os.path.split(file_path)[1].split("_extension")[0]
         graphql_path = os.path.split(os.path.split(file_path)[0])[0]
@@ -25,8 +25,7 @@ def make_extension_dirs(paths, only_folders):
         # print(root_name)
 
         # Make base directory for doctype
-        doctype_root_path = make_dir_safe(
-            os.path.join(graphql_path, doctype_name+"/"))
+        doctype_root_path = make_dir_safe(os.path.join(graphql_path, doctype_name+"/"))
 
         schema_content = ""
 
@@ -36,28 +35,30 @@ def make_extension_dirs(paths, only_folders):
 
             if queries != [] or mutations != []:
                 schema_content = generate_schema_content(
-                    queries, mutations, root_name, doctype_name)
+                    queries,
+                    mutations,
+                    root_name,
+                    doctype_name
+                )
 
         # Inside, make the resolvers dir, and pop down a schema.py and __init__.py file
         make_file(os.path.join(doctype_root_path, "__init__.py"), "")
-        make_file(os.path.join(doctype_root_path,
-                               "schema.py"), schema_content)
-        resolver_root_path = make_dir_safe(
-            os.path.join(doctype_root_path, "resolvers/"))
+        make_file(os.path.join(doctype_root_path, "schema.py"), schema_content)
+        resolver_root_path = make_dir_safe(os.path.join(doctype_root_path, "resolvers/"))
 
         # Inside, make the queries and mutations dir, popping down another __init__.py file
-        make_file(os.path.join(resolver_root_path, "__init__.py"),
-                  "from .queries import *\nfrom .mutations import *")
-        query_root_path = make_dir_safe(
-            os.path.join(resolver_root_path, "queries/"))
-        mutation_root_path = make_dir_safe(
-            os.path.join(resolver_root_path, "mutations/"))
+        make_file(
+            os.path.join(resolver_root_path, "__init__.py"),
+            "from .queries import *\nfrom .mutations import *"
+        )
+        query_root_path = make_dir_safe(os.path.join(resolver_root_path, "queries/"))
+        mutation_root_path = make_dir_safe(os.path.join(resolver_root_path, "mutations/"))
 
         # Inside both, pop down __init__.py files...
         make_file(os.path.join(query_root_path, "__init__.py"), "")
         make_file(os.path.join(mutation_root_path, "__init__.py"), "")
 
-        #...and decide if you want to genertate files
+        # ...and decide if you want to genertate files
         if not only_folders:
 
             binding_types = []
@@ -70,8 +71,11 @@ def make_extension_dirs(paths, only_folders):
                 generate_functions(mutations, mutation_root_path)
                 binding_types.append("mutations")
 
-            edited = edit_hooks_file(os.path.join(up_root_path, root_name),
-                            doctype_name, binding_types)
+            edited = edit_hooks_file(
+                os.path.join(up_root_path, root_name),
+                doctype_name,
+                binding_types
+            )
 
             if edited:
                 hooks_edited = True
@@ -80,4 +84,3 @@ def make_extension_dirs(paths, only_folders):
         print("Successfully edited hooks.py")
     else:
         print("No changes made to hooks.py")
-

--- a/frappe_graphql/utils/generate_resolvers/resolvers.py
+++ b/frappe_graphql/utils/generate_resolvers/resolvers.py
@@ -1,0 +1,187 @@
+import frappe
+import os
+import re
+
+
+def scan_extension_for_functions(path):
+
+    # open the file
+    file = open(path, 'r')
+
+    # replace all spaces with nothing
+    contents = file.read()
+
+    contents = contents.replace(" ", "")
+
+    in_query_block = False
+    in_mutation_block = False
+
+    query_names = []
+    mutation_names = []
+
+    # Go through contents line by line
+    for line in contents.splitlines():
+
+        if "}" in line:
+            in_query_block = False
+            in_mutation_block = False
+
+        if in_query_block:
+            if line != "":
+                query_names.append(re.match(r'^\w*', line).group())
+
+        if in_mutation_block:
+            if line != "":
+                mutation_names.append(re.match(r'^\w*', line).group())
+
+        if "Query" in line:
+            in_query_block = True
+
+        if "Mutation" in line:
+            in_mutation_block = True
+
+    '''DEBUG PRINT'''
+    # print("Queries found: ", query_names)
+    # print("Mutation found: ", mutation_names)
+
+    return query_names, mutation_names
+
+
+def generate_schema_content(queries, mutations, root_name, doc_name):
+
+    contents = ""
+
+    header = 'import {{root_name}}.graphql.{{doc_name}}.resolvers as {{doc_name}}_resolver\nfrom graphql import GraphQLSchema'
+
+    binding_header = 'def bind_{{doc_name}}_{{type}}(schema: GraphQLSchema):'
+
+    binding = '    schema.{{type}}_type.fields["{{field}}"].resolve = \\\n      {{doc_name}}_resolver.{{field_slug}}_resolver'
+
+    contents += frappe.render_template(header,
+                                       frappe._dict(root_name=root_name, doc_name=doc_name))
+    contents += "\n\n\n"
+
+    if queries != []:
+        contents += frappe.render_template(binding_header,
+                                           frappe._dict(doc_name=doc_name, type="queries"))
+        contents += "\n\n"
+        for query in queries:
+            contents += frappe.render_template(binding, frappe._dict(
+                type="query", field=query, doc_name=doc_name, field_slug=sluggify_camelCase(query)))
+            contents += "\n\n"
+
+    if mutations != []:
+        contents += "\n"
+        contents += frappe.render_template(binding_header,
+                                           frappe._dict(doc_name=doc_name, type="mutations"))
+        contents += "\n\n"
+
+        for mutation in mutations:
+            contents += frappe.render_template(binding, frappe._dict(
+                type="mutation", field=mutation, doc_name=doc_name, field_slug=sluggify_camelCase(mutation)))
+            contents += "\n\n"
+
+    return contents
+
+
+def generate_functions(function_names, output_path):
+
+    header = 'from graphql import GraphQLResolveInfo\n\n\n'
+    function = 'def {{field}}_resolver(obj, info: GraphQLResolveInfo, **kwargs):\n    return # Your resolver implementation\n\n'
+    init_entry = 'from .{{function_file}} import *\n\n'
+    init_contents = ''
+    init_path = os.path.join(output_path, "__init__")
+
+    # for ever query/mutation:
+    for function_name in function_names:
+        name = sluggify_camelCase(function_name)
+        file_path = os.path.join(output_path, name)
+
+        file_contents = header
+        file_contents += frappe.render_template(
+            function, frappe._dict(field=name))
+        file = open(f'{file_path}.py', 'w')
+        file.write(file_contents)
+        file.close()
+
+        # Make an entry in the contents of the init.py
+        init_contents += frappe.render_template(
+            init_entry, frappe._dict(function_file=name))
+
+    # Make the init.py file
+    file = open(f'{init_path}.py', 'w')
+    file.write(init_contents)
+    file.close()
+
+
+def edit_hooks_file(root_path, doc_name, binding_types):
+    '''
+    Will append the binding to hooks.py
+
+    If bindings already exists, no changes will be made. 
+    Returns True if changes were made, False otherwise.
+    '''
+
+    '''DEBUG PRINT'''
+    # print(binding_types)
+
+    schema_binding_line = "    \"{{root_name}}.graphql.{{doctype_name}}.schema.bind_{{doctype_name}}_{{binding_type}}\",\n\n"
+
+    root_name = os.path.split(root_path)[1]
+
+    try:
+        file = open(os.path.join(root_path, 'hooks.py'), 'r+')
+        contents = file.read()
+        new_contents = ''
+
+        lines_to_generate = []
+        for binding_type in binding_types:
+            lines_to_generate.append(frappe.render_template(schema_binding_line, frappe._dict(
+                root_name=root_name, doctype_name=doc_name, binding_type=binding_type)))
+
+        in_schema_block = False
+        written_lines = 0
+        for line in contents.splitlines(keepends=True):
+
+            if "graphql_schema_processors" in line:
+                in_schema_block = True
+
+            # If line already exists in file, remove it from the list
+            if line in lines_to_generate:
+                lines_to_generate.remove(line)
+
+            if in_schema_block and line.replace(" ", '') == "]\n":
+                in_schema_block = False
+
+                for line_to_generate in lines_to_generate:
+                    new_contents += "\n"
+                    new_contents += line_to_generate
+                    written_lines += 1
+
+            new_contents += line
+
+        file.seek(0)
+        file.write(new_contents)
+        file.close()
+
+        if written_lines > 0:
+
+            '''DEBUG PRINT'''
+            #print("hooks.py successfully edited.")
+
+            return True
+        else:
+
+            '''DEBUG PRINT'''
+            #print("No changes made to hooks.py")
+
+            return False
+
+    except Exception as e:
+        file.close()
+        print("Failed to edit hooks.py")
+        print(e)
+
+
+def sluggify_camelCase(string):
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', string).lower()


### PR DESCRIPTION
A command to generate resolver files and folders for queries/mutations automatically by looking at `_extension.graphql` files. 

`_extension.graphql` files are written to extend functionality beyond the ones automatically generated by `frappe_graphql`, including custom queries and mutations. However, there is a lot of boilerplate code and files/folder structure that has to be written/created for every query/mutation; small but tedious steps:
1. Defining the query/mutation in an `_extension.graphql` file.
2. Creating `doctype/resolvers/queries` and/or `doctype/resolvers/mutations` directories in the `graphql` folder and populating them with `__init__.py` files.
3. Creating a python file or multiple files to place the resolver functions.
4. Defining the resolver functions using boilerplate code. 
5. Creating a `schema.py` file, importing all the resolvers in, making an entry for every query/mutation, copy-pasting each query/mutation name as a string, and binding them to their resolvers
6. Editing the `hooks.py` file to add all the bindings

This command can automate all the steps after step 1. 

---

A simple use of the command would be something like:
```bash
bench --site your.site graphql generate_resolvers -dt "My Doc" --only-folders
```
What this will do is try to find a `my_doc_extension.graphql`  file in any apps installed on the site (The DocType does not have to exist, neither a `doc_type.graphql` file, just the `_extension` file), and generate the following empty files/directories:
![Screenshot from 2021-09-06 11-58-38](https://user-images.githubusercontent.com/30027453/132181492-985dcafa-000c-4607-ad67-78129a483d54.png)
These can be then be used as a jumping off point to implementing resolvers and bindings manually.

---

The command can also be used to automate the rest of the steps by removing the `--only-folders` option:
```bash
bench --site your.site graphql generate_resolvers -dt "My Doc"
```
The `my_doc_extension.graphql` file contains, among other things, a query and a mutation, like so:
```graphql
type Query {
    myQuery:Int
}

type Mutation{
    myMutation:Int
}
```
...which creates the following file/dir structure:
![Screenshot from 2021-09-06 11-35-44](https://user-images.githubusercontent.com/30027453/132179315-3d62cf83-cdbb-4ed8-a6a7-24342888eaaf.png)
...and generates the following content in files:
```python
# my_query.py
from graphql import GraphQLResolveInfo


def my_query_resolver(obj, info: GraphQLResolveInfo, **kwargs):
    return # Your resolver implementation

```
```python
# queries/__init__.py`
from .my_query import *

```
```python
# schema.py
import romman_core.graphql.my_doc.resolvers as my_doc_resolver
from graphql import GraphQLSchema


def bind_my_doc_queries(schema: GraphQLSchema):

    schema.query_type.fields["myQuery"].resolve = \
      my_doc_resolver.my_query_resolver


def bind_my_doc_mutations(schema: GraphQLSchema):

    schema.mutation_type.fields["myMutation"].resolve = \
      my_doc_resolver.my_mutation_resolver

```
...and makes the following changes in `hooks.py`
![Screenshot from 2021-09-06 12-08-31](https://user-images.githubusercontent.com/30027453/132182844-2cd130f3-3862-4d4a-9337-efde219df9b0.png)

---

I've tested out the command on some repos, and it seems to work well. Feedback  would be appreciated.  

Some other options that can be used with the command:
```bash
bench --site your.site graphql generate_resolvers --module "Module Name"
```
```bash
bench --site your.site graphql generate_resolvers --app "App Name"
```

---

:warning: If you run the command yourself, please take care, as it will overwrite any relevant files and folders, and make changes to the `hooks.py` file without confirmation. 

---

### Todo:
Some features that can be added if there is interest/need:
- [ ] Need to extend the functionality to make use of a template system. 