### PR TITLE
fix: Added normal print out to Graphql errors 

### DIFF
--- a/frappe_graphql/api.py
+++ b/frappe_graphql/api.py
@@ -113,7 +113,7 @@ def log_error(query, variables, operation_name, output):
 
     tracebacks.append(f"Frappe Traceback: \n{frappe.get_traceback()}")
     if frappe.conf.get("developer_mode"):
-       frappe.errprint(tracebacks)
+        frappe.errprint(tracebacks)
 
     tracebacks = "\n==========================================\n".join(tracebacks)
     if frappe.conf.get("developer_mode"):

--- a/frappe_graphql/api.py
+++ b/frappe_graphql/api.py
@@ -113,9 +113,11 @@ def log_error(query, variables, operation_name, output):
 
     tracebacks.append(f"Frappe Traceback: \n{frappe.get_traceback()}")
     if frappe.conf.get("developer_mode"):
-        frappe.errprint(tracebacks)
+       frappe.errprint(tracebacks)
 
     tracebacks = "\n==========================================\n".join(tracebacks)
+    if frappe.conf.get("developer_mode"):
+        print(tracebacks)
     error_log = frappe.new_doc("GraphQL Error Log")
     error_log.update(frappe._dict(
         title="GraphQL API Error",


### PR DESCRIPTION
The `frappe.errprint` statement is currently used to pass back any errors caused by a gql query. It also prints out the error to the console. When passing the error back, it rightly escapes any special characters, but a side effect of this is that the same string filled with escaped sequences is printed to console as well.

Please consider merging this PR which adds another normal python print out just after the one generated by frappe, so that it is easier to debug errors directly from console as a Quality-of-Life change. :smile: 