### PR TITLE
fix: Improve child-doc resolver Performance

### DIFF
--- a/frappe_graphql/utils/resolver/document_resolver.py
+++ b/frappe_graphql/utils/resolver/document_resolver.py
@@ -1,6 +1,7 @@
 from graphql import GraphQLResolveInfo, GraphQLEnumType
 
 import frappe
+from frappe.utils import cint
 from frappe.model import default_fields
 from frappe.model.document import BaseDocument
 
@@ -13,12 +14,20 @@ def document_resolver(obj, info: GraphQLResolveInfo, **kwargs):
         return None
 
     cached_doc = obj
+    __ignore_perms = cint(obj.get("__ignore_perms", 0) == 1)
+
+    if not isinstance(cached_doc, BaseDocument) and info.field_name not in cached_doc:
+        try:
+            cached_doc = frappe.get_cached_doc(doctype, obj.get("name"))
+        except BaseException:
+            pass
+
     if frappe.is_table(doctype=doctype) and isinstance(cached_doc, BaseDocument):
         # Saves a lot of frappe.get_cached_doc calls
         # - We do not want to check perms for child tables
         # - We load child doc only if doc is not an instance of BaseDocument
         pass
-    elif obj.get("__ignore_perms", 0) == 1:
+    elif __ignore_perms:
         pass
     else:
         try:
@@ -26,7 +35,8 @@ def document_resolver(obj, info: GraphQLResolveInfo, **kwargs):
             # verbose check of is_owner of doc
             # In the case when object signature lead into document resolver
             # But the document no longer exists in database
-            cached_doc = frappe.get_cached_doc(doctype, obj.get("name"))
+            if not isinstance(cached_doc, BaseDocument):
+                cached_doc = frappe.get_cached_doc(doctype, obj.get("name"))
 
             frappe.has_permission(doctype=doctype, doc=cached_doc, throw=True)
             role_permissions = frappe.permissions.get_role_permissions(doctype)
@@ -61,18 +71,28 @@ def document_resolver(obj, info: GraphQLResolveInfo, **kwargs):
                 value, str) and not frappe.flags.ignore_doc_resolver_translation:
             return frappe._(value)
 
+        if __ignore_perms:
+            if isinstance(value, list):
+                for item in value:
+                    item.update({"__ignore_perms": __ignore_perms})
+            elif isinstance(value, (BaseDocument, dict)):
+                value.update({"__ignore_perms": __ignore_perms})
+
         return value
 
     if info.field_name.endswith("__name"):
         fieldname = info.field_name.split("__name")[0]
-        return _get_value(fieldname)
+        return _get_value(fieldname, ignore_translation=True)
     elif df:
         if df.fieldtype in ("Link", "Dynamic Link"):
             if not _get_value(df.fieldname):
                 return None
             link_dt = df.options if df.fieldtype == "Link" else \
-                _get_value(df.options)
-            return frappe._dict(name=_get_value(df.fieldname), doctype=link_dt)
+                _get_value(df.options, ignore_translation=True)
+            return frappe._dict(
+                name=_get_value(df.fieldname, ignore_translation=True),
+                doctype=link_dt,
+                __ignore_perms=__ignore_perms)
         elif df.fieldtype == "Select" and isinstance(info.return_type, GraphQLEnumType):
             # We allow Select fields whose returnType is just Strings
             value = _get_value(df.fieldname, ignore_translation=True) or ""

--- a/frappe_graphql/utils/resolver/tests/test_document_resolver.py
+++ b/frappe_graphql/utils/resolver/tests/test_document_resolver.py
@@ -1,0 +1,65 @@
+import unittest
+from frappe_graphql.graphql import execute
+
+
+class TestDocumentResolver(unittest.TestCase):
+    def test_get_administrator(self):
+        """
+        Test basic get_doc
+        """
+        r = execute(
+            query="""
+            query FetchAdmin($user: String!) {
+                User(name: $user) {
+                    doctype
+                    name
+                    email
+                    full_name
+                }
+            }
+            """,
+            variables={
+                "user": "administrator"
+            }
+        )
+        self.assertIsNone(r.get("errors"))
+        self.assertIsInstance(r.get("data"), dict)
+        self.assertIsInstance(r.get("data").get("User", None), dict)
+
+        admin = r.get("data").get("User")
+        self.assertEqual(admin.get("doctype"), "User")
+        self.assertEqual(admin.get("name"), "administrator")
+        self.assertEqual(admin.get("full_name"), "Administrator")
+
+    def test_link_fields(self):
+        """
+        Test user.roles.role__name is equal to user.roles.role.name
+        """
+        r = execute(
+            query="""
+            query FetchAdmin($user: String!) {
+                User(name: $user) {
+                    doctype
+                    name
+                    full_name
+                    roles {
+                        role__name
+                        role {
+                            name
+                        }
+                    }
+                }
+            }
+            """,
+            variables={
+                "user": "administrator"
+            }
+        )
+        self.assertIsNone(r.get("errors"))
+        self.assertIsInstance(r.get("data"), dict)
+        self.assertIsInstance(r.get("data").get("User", None), dict)
+
+        admin = r.get("data").get("User")
+        for role in admin.get("roles"):
+            self.assertEqual(role.get("role__name"),
+                             role.get("role").get("name"))

--- a/frappe_graphql/utils/resolver/tests/test_document_resolver.py
+++ b/frappe_graphql/utils/resolver/tests/test_document_resolver.py
@@ -1,8 +1,31 @@
 import unittest
-from frappe_graphql.graphql import execute
+import frappe
+
+from frappe_graphql.graphql import get_schema, execute
+
+"""
+The following aspects of Document Resolver is tested here:
+- BASIC_TESTS                   ✔️
+- LINK_FIELD_TESTS              ✔️
+- DYNAMIC_LINK_FIELD_TESTS      ⌛
+- CHILD_TABLE_TESTS             ✔️
+- SELECT_FIELD_TESTS            ✔️
+- IGNORE_PERMS_TESTS
+- DB_DELETED_DOC_TESTS
+- TRANSLATION_TESTS
+
+You can search for any one of the above keys to jump to related tests
+"""
 
 
 class TestDocumentResolver(unittest.TestCase):
+
+    ADMIN_DOCNAME = "administrator"
+
+    """
+    BASIC_TESTS
+    """
+
     def test_get_administrator(self):
         """
         Test basic get_doc
@@ -19,7 +42,7 @@ class TestDocumentResolver(unittest.TestCase):
             }
             """,
             variables={
-                "user": "administrator"
+                "user": self.ADMIN_DOCNAME
             }
         )
         self.assertIsNone(r.get("errors"))
@@ -31,7 +54,51 @@ class TestDocumentResolver(unittest.TestCase):
         self.assertEqual(admin.get("name"), "administrator")
         self.assertEqual(admin.get("full_name"), "Administrator")
 
+    """
+    LINK_FIELD_TESTS
+    """
+
     def test_link_fields(self):
+        """
+        Test User.language
+        Set User.Administrator.language to en if not set already
+        """
+        if not frappe.db.get_value("User", self.ADMIN_DOCNAME, "language"):
+            frappe.db.set_value("User", self.ADMIN_DOCNAME, "language", "en")
+
+        r = execute(
+            query="""
+            query FetchAdmin($user: String!) {
+                User(name: $user) {
+                    doctype
+                    name
+                    email
+                    full_name
+                    language__name
+                    language {
+                        name
+                        language_name
+                    }
+                }
+            }
+            """,
+            variables={
+                "user": self.ADMIN_DOCNAME
+            }
+        )
+        self.assertIsNone(r.get("errors"))
+
+        admin = r.get("data").get("User")
+        self.assertIsNotNone(admin.get("language"))
+        self.assertEqual(admin.get("language__name"), admin.get("language").get("name"))
+
+        lang = admin.get("language")
+        self.assertEqual(
+            lang.get("language_name"),
+            frappe.db.get_value("Language", lang.get("name"), "language_name")
+        )
+
+    def test_child_table_link_fields(self):
         """
         Test user.roles.role__name is equal to user.roles.role.name
         """
@@ -63,3 +130,150 @@ class TestDocumentResolver(unittest.TestCase):
         for role in admin.get("roles"):
             self.assertEqual(role.get("role__name"),
                              role.get("role").get("name"))
+
+    """
+    DYNAMIC_LINK_FIELD_TESTS
+    """
+
+    """
+    CHILD_TABLE_TESTS
+    """
+
+    def test_child_table(self):
+        """
+        Test user.roles
+        """
+        r = execute(
+            query="""
+            query FetchAdmin($user: String!) {
+                User(name: $user) {
+                    doctype
+                    name
+                    full_name
+                    roles {
+                        doctype name
+                        parent__name parenttype parentfield
+                        role__name
+                        role {
+                            name
+                        }
+                    }
+                }
+            }
+            """,
+            variables={
+                "user": "administrator"
+            }
+        )
+        self.assertIsNone(r.get("errors"))
+
+        admin = r.get("data").get("User")
+        for role in admin.get("roles"):
+            self.assertEqual(role.get("doctype"), "Has Role")
+
+            self.assertEqual(role.get("parenttype"), admin.get("doctype"))
+            self.assertEqual(role.get("parent__name").lower(), admin.get("name").lower())
+            self.assertEqual(role.get("parentfield"), "roles")
+
+            self.assertEqual(role.get("role__name"),
+                             role.get("role").get("name"))
+    """
+    SELECT_FIELD_TESTS
+    """
+
+    def test_simple_select(self):
+        r = execute(
+            query="""
+            query FetchAdmin($user: String!) {
+                User(name: $user) {
+                    full_name
+                    desk_theme
+                }
+            }
+            """,
+            variables={
+                "user": "administrator"
+            }
+        )
+
+        self.assertIsNone(r.get("errors"))
+        admin = r.get("data").get("User")
+
+        self.assertIn(admin.get("desk_theme"), ["Light", "Dark"])
+
+    def test_enum_select(self):
+        """
+        Update SDL.User.desk_theme return type to be an Enum
+        """
+        from graphql import GraphQLScalarType, GraphQLEnumType
+        schema = get_schema()
+        user_type = schema.type_map.get("User")
+        original_type = None
+        if isinstance(user_type.fields.get("desk_theme").type, GraphQLScalarType):
+            original_type = user_type.fields.get("desk_theme").type
+            user_type.fields.get("desk_theme").type = GraphQLEnumType(
+                name="UserDeskThemeType",
+                values={
+                    "DARK": "DARK",
+                    "LIGHT": "LIGHT"
+                }
+            )
+
+        r = execute(
+            query="""
+            query FetchAdmin($user: String!) {
+                User(name: $user) {
+                    full_name
+                    desk_theme
+                }
+            }
+            """,
+            variables={
+                "user": "administrator"
+            }
+        )
+
+        self.assertIsNone(r.get("errors"))
+        admin = r.get("data").get("User")
+
+        self.assertIn(admin.get("desk_theme"), ["LIGHT", "DARK"])
+
+        # Set back the original type
+        if original_type is not None:
+            user_type.fields.get("desk_theme").type = original_type
+
+    """
+    IGNORE_PERMS_TESTS
+    """
+
+    """
+    DB_DELETED_DOC_TESTS
+    """
+    def test_deleted_doc_resolution(self):
+        d = frappe.get_doc(dict(
+            doctype="User",
+            first_name="Example A",
+            email="example_a@test.com",
+            send_welcome_email=0
+        )).insert()
+
+        d.delete()
+
+        # We cannot call Query.User(name: d.name) now since its deleted
+        r = execute(
+            query="""
+            query FetchAdmin($user: String!) {
+                User(name: $user) {
+                    full_name
+                    desk_theme
+                }
+            }
+            """,
+            variables={
+                "user": d.name
+            }
+        )
+        print(r)
+    """
+    TRANSLATION_TESTS
+    """

--- a/frappe_graphql/utils/resolver/tests/test_document_resolver.py
+++ b/frappe_graphql/utils/resolver/tests/test_document_resolver.py
@@ -2,7 +2,7 @@ import unittest
 import frappe
 
 from frappe_graphql.graphql import get_schema, execute
-from graphql.type.definition import GraphQLArgument, GraphQLField, GraphQLScalarType
+from graphql import GraphQLArgument, GraphQLField, GraphQLScalarType, GraphQLString
 
 """
 The following aspects of Document Resolver is tested here:
@@ -11,9 +11,10 @@ The following aspects of Document Resolver is tested here:
 - DYNAMIC_LINK_FIELD_TESTS      ⌛
 - CHILD_TABLE_TESTS             ✔️
 - SELECT_FIELD_TESTS            ✔️
-- IGNORE_PERMS_TESTS
-- DB_DELETED_DOC_TESTS
-- TRANSLATION_TESTS
+- IGNORE_PERMS_TESTS            ✔️
+- DB_DELETED_DOC_TESTS          ✔️
+- TRANSLATION_TESTS             ⌛
+- OWNER / MODIFIED_BY TESTS     ⌛
 
 You can search for any one of the above keys to jump to related tests
 """
@@ -22,6 +23,10 @@ You can search for any one of the above keys to jump to related tests
 class TestDocumentResolver(unittest.TestCase):
 
     ADMIN_DOCNAME = "administrator"
+
+    def tearDown(self) -> None:
+        if frappe.local.user != "Administrator":
+            frappe.set_user("Administrator")
 
     """
     BASIC_TESTS
@@ -131,10 +136,6 @@ class TestDocumentResolver(unittest.TestCase):
         for role in admin.get("roles"):
             self.assertEqual(role.get("role__name"),
                              role.get("role").get("name"))
-
-    """
-    DYNAMIC_LINK_FIELD_TESTS
-    """
 
     """
     CHILD_TABLE_TESTS
@@ -247,6 +248,83 @@ class TestDocumentResolver(unittest.TestCase):
     IGNORE_PERMS_TESTS
     """
 
+    def test_ignore_perms(self):
+        administrator = frappe.get_doc("User", "administrator")
+        frappe.set_user("Guest")
+        schema = get_schema()
+        schema.query_type.fields["GetAdmin"] = GraphQLField(
+            type_=schema.type_map["User"],
+            resolve=lambda obj, info, **kwargs: dict(
+                doctype="User", name="Administrator", __ignore_perms=True)
+        )
+
+        r = execute(
+            query="""
+            {
+                GetAdmin {
+                    email
+                    full_name
+                    desk_theme
+                    roles {
+                        role__name
+                    }
+                }
+            }
+            """
+        )
+
+        self.assertIsNone(r.get("errors"))
+        admin = frappe._dict(r.get("data").get("GetAdmin"))
+
+        self.assertEqual(admin.email, administrator.email)
+        self.assertEqual(len(admin.roles), len(administrator.roles))
+
+    def test_ignore_perms_child_doc_and_link_field(self):
+        """
+        Has Role {
+            __ignore_perms: 1
+            role__name
+            role {
+                should be readable without perm errors
+            }
+        }
+        """
+        frappe.set_user("Guest")
+        has_role_name = frappe.db.get_value("Has Role", {})
+
+        schema = get_schema()
+        schema.query_type.fields["GetHasRole"] = GraphQLField(
+            type_=schema.type_map["HasRole"],
+            args=dict(
+                name=GraphQLString
+            ),
+            resolve=lambda obj, info, **kwargs: dict(
+                doctype="Has Role", name=kwargs.get("name"), __ignore_perms=True)
+        )
+
+        r = execute(
+            query="""
+            query GetHasRole($name: String!) {
+                GetHasRole(name: $name) {
+                    name
+                    doctype
+                    role__name
+                    role {
+                        name
+                    }
+                }
+            }
+            """,
+            variables={
+                "name": has_role_name
+            }
+        )
+        self.assertIsNone(r.get("errors"))
+
+        has_role = frappe._dict(r.get("data").get("GetHasRole"))
+        self.assertEqual(has_role.name, has_role_name)
+        self.assertEqual(has_role.role__name, has_role.role.get("name"))
+
     """
     DB_DELETED_DOC_TESTS
     """
@@ -297,7 +375,6 @@ class TestDocumentResolver(unittest.TestCase):
                 "user": d
             }
         )
-        print(r)
         resolved_doc = frappe._dict(r.get("data").get("EchoUser"))
 
         self.assertEqual(resolved_doc.doctype, d.doctype)
@@ -306,7 +383,3 @@ class TestDocumentResolver(unittest.TestCase):
         self.assertEqual(resolved_doc.full_name, d.full_name)
         self.assertEqual(len(resolved_doc.roles), 1)
         self.assertEqual(resolved_doc.roles[0].get("role__name"), "System Manager")
-
-    """
-    TRANSLATION_TESTS
-    """


### PR DESCRIPTION
## Preface
- `get_cached_doc` was being called for each and every document being handled by gql-resolver be it child-doc or normal-doc.
- `get_cached_doc` works as indented - loads from db on first call, serves from cache on second call
- permission check is not required for child docs.
- Number of db calls on a single get_doc is huge


## Observations
<details>
<summary>Before & After</summary>

Query:
```gql
{
  Users(first: 100) {
    pageInfo {
      hasNextPage hasPreviousPage startCursor endCursor
    }
    totalCount
    edges {
      cursor
      node {
        full_name
        email
        roles {
          role__name
        }
      }
    }
  }
}
```
Before:
![image](https://user-images.githubusercontent.com/12441615/143176953-1f00102d-1348-4304-8adc-ddbdb5e7a987.png)

After:
![image](https://user-images.githubusercontent.com/12441615/143176973-bd7be584-4d05-4428-89e5-04d46d67b740.png)

</details>

Significant drop in number of queries can be observed.
There is a lot more room for improvements - let this be the first step 😄 