### PR TITLE
fix: Prevent generation of Child Doc cursors, removing pagination support

### DIFF
--- a/frappe_graphql/commands/__init__.py
+++ b/frappe_graphql/commands/__init__.py
@@ -21,10 +21,12 @@ def graphql():
               help="Ignore custom fields generation")
 @click.option("--disable-enum-select-fields", is_flag=True, default=False,
               help="Disable generating GQLEnums for Frappe Select DocFields")
+@click.option("--include_default_childdoctype_queries", is_flag=True, default=False,
+              help="Include default queries for Child DocTypes (not recommended)")
 @pass_context
 def generate_sdl(
     context, output_dir=None, app=None, module=None, doctype=None,
-    ignore_custom_fields=False, disable_enum_select_fields=False
+    ignore_custom_fields=False, disable_enum_select_fields=False, include_default_childdoctype_queries=False
 ):
     site = get_site(context=context)
     try:
@@ -45,7 +47,8 @@ def generate_sdl(
             modules=list(module),
             doctypes=list(doctype),
             ignore_custom_fields=ignore_custom_fields,
-            disable_enum_select_fields=disable_enum_select_fields
+            disable_enum_select_fields=disable_enum_select_fields,
+            include_default_childdoctype_queries=include_default_childdoctype_queries
         )
     finally:
         frappe.destroy()

--- a/frappe_graphql/utils/generate_sdl/__init__.py
+++ b/frappe_graphql/utils/generate_sdl/__init__.py
@@ -23,8 +23,15 @@ SDL_PREDEFINED_DOCTYPES = [
 ]
 
 
-def make_doctype_sdl_files(target_dir, app=None, modules=[], doctypes=[],
-                           ignore_custom_fields=False, disable_enum_select_fields=False):
+def make_doctype_sdl_files(
+    target_dir,
+    app=None,
+    modules=[],
+    doctypes=[],
+    ignore_custom_fields=False,
+    disable_enum_select_fields=False,
+    include_default_childdoctype_queries=False,
+):
     specific_doctypes = doctypes or []
     doctypes = get_doctypes(
         app=app,
@@ -34,7 +41,8 @@ def make_doctype_sdl_files(target_dir, app=None, modules=[], doctypes=[],
 
     options = frappe._dict(
         disable_enum_select_fields=disable_enum_select_fields,
-        ignore_custom_fields=ignore_custom_fields
+        ignore_custom_fields=ignore_custom_fields,
+        include_default_childdoctype_queries=include_default_childdoctype_queries
     )
 
     if not os.path.exists(target_dir):

--- a/frappe_graphql/utils/generate_sdl/doctype.py
+++ b/frappe_graphql/utils/generate_sdl/doctype.py
@@ -23,13 +23,15 @@ def get_doctype_sdl(doctype, options):
     if not options.disable_enum_select_fields:
         sdl += get_select_docfield_enums(meta=meta, options=options)
 
-    # DocTypeSortingInput
-    if not meta.issingle:
-        sdl += get_sorting_input(meta)
-        sdl += get_connection_type(meta)
+    if not meta.istable or options.include_default_childdoctype_queries:
 
-    # Extend QueryType
-    sdl += get_query_type_extension(meta)
+        # DocTypeSortingInput
+        if not meta.issingle:
+            sdl += get_sorting_input(meta)
+            sdl += get_connection_type(meta)
+
+        # Extend QueryType
+        sdl += get_query_type_extension(meta)
 
     return sdl
 


### PR DESCRIPTION
This PR adds a new flag to `generate_sdl`: "include_default_childdoctype_queries". This is introduced because this PR changes the default behavior of the `generate_sdl` command such as to prevent the generation of cursors and queries for Child Docs when the `generate_sdl` command is used, patching a potential security issue. 