### PR TITLE
feat: Basic Perms for new Resolvers

### DIFF
--- a/frappe_graphql/utils/resolver/dataloaders/doctype_loader.py
+++ b/frappe_graphql/utils/resolver/dataloaders/doctype_loader.py
@@ -19,7 +19,7 @@ def get_doctype_dataloader(doctype: str) -> DataLoader:
 def _get_document_loader_fn(doctype: str):
 
     def _load_documents(keys: List[str]):
-        docs = frappe.get_all(
+        docs = frappe.get_list(
             doctype=doctype,
             filters=[["name", "IN", keys]],
             fields=["*", f"'{doctype}' as doctype"],

--- a/frappe_graphql/utils/resolver/link_field.py
+++ b/frappe_graphql/utils/resolver/link_field.py
@@ -50,6 +50,10 @@ def _resolve_link_field(obj, info: GraphQLResolveInfo, **kwargs):
     if not (dt and dn):
         return None
 
+    # We need a dataloader solution for permission check
+    if not frappe.has_permission(doctype=dt, doc=dn):
+        raise frappe.PermissionError(frappe._("No permission for {0}").format(dt + " " + dn))
+
     return get_doctype_dataloader(dt).load(dn)
 
 
@@ -65,6 +69,10 @@ def _resolve_dynamic_link_field(obj, info: GraphQLResolveInfo, **kwargs):
     dn = obj.get(info.field_name)
     if not dn:
         return None
+
+    # We need a dataloader solution for permission check
+    if not frappe.has_permission(doctype=dt, doc=dn):
+        raise frappe.PermissionError(frappe._("No permission for {0}").format(dt + " " + dn))
 
     return get_doctype_dataloader(dt).load(dn)
 

--- a/frappe_graphql/utils/resolver/link_field.py
+++ b/frappe_graphql/utils/resolver/link_field.py
@@ -50,10 +50,7 @@ def _resolve_link_field(obj, info: GraphQLResolveInfo, **kwargs):
     if not (dt and dn):
         return None
 
-    # We need a dataloader solution for permission check
-    if not frappe.has_permission(doctype=dt, doc=dn):
-        raise frappe.PermissionError(frappe._("No permission for {0}").format(dt + " " + dn))
-
+    # Permission check is done within get_doctype_dataloader via get_list
     return get_doctype_dataloader(dt).load(dn)
 
 
@@ -70,10 +67,7 @@ def _resolve_dynamic_link_field(obj, info: GraphQLResolveInfo, **kwargs):
     if not dn:
         return None
 
-    # We need a dataloader solution for permission check
-    if not frappe.has_permission(doctype=dt, doc=dn):
-        raise frappe.PermissionError(frappe._("No permission for {0}").format(dt + " " + dn))
-
+    # Permission check is done within get_doctype_dataloader via get_list
     return get_doctype_dataloader(dt).load(dn)
 
 

--- a/frappe_graphql/utils/resolver/root_query.py
+++ b/frappe_graphql/utils/resolver/root_query.py
@@ -35,11 +35,18 @@ def _get_doc_resolver(obj, info: GraphQLResolveInfo, **kwargs):
     if is_single(dt):
         kwargs["name"] = dt
 
-    return get_doctype_dataloader(dt).load(kwargs["name"])
+    dn = kwargs["name"]
+    if not frappe.has_permission(doctype=dt, doc=dn):
+        raise frappe.PermissionError(frappe._("No permission for {0}").format(dt + " " + dn))
+
+    return get_doctype_dataloader(dt).load(dn)
 
 
 def _doc_cursor_resolver(obj, info: GraphQLResolveInfo, **kwargs):
     plural_doctype = get_plural_doctype(info.field_name)
-    frappe.has_permission(doctype=plural_doctype, throw=True)
+
+    frappe.has_permission(
+        doctype=plural_doctype,
+        throw=True)
 
     return CursorPaginator(doctype=plural_doctype).resolve(obj, info, **kwargs)


### PR DESCRIPTION
The aim is to provide basic permission checks for the default queries and resolvers.

Only three kinds of permissions are implemented:
- `Query.DocType(name: ID!)`  
Straightforward frappe.has_permission call on the doctype & docname is done here
- `Query.DocTypes(args: CursorArgs!)`
Straightforward frappe.has_permission call on just the doctype is done here
- `DocType.link_field: BaseDocument`  
frappe.has_permission call is done on doctype & docname. This might be a bit heavy to invoke for all Link fields given that frappe,has_permission has internal call to frappe.get_doc. A dataloader solution would be helpful here in the future.