### PR TITLE
fix: False Positives in Default Resolver Setup

### DIFF
--- a/frappe_graphql/utils/resolver/__init__.py
+++ b/frappe_graphql/utils/resolver/__init__.py
@@ -1,4 +1,7 @@
-from graphql import GraphQLSchema, GraphQLType, GraphQLResolveInfo, GraphQLNonNull
+from graphql import (
+    GraphQLSchema, GraphQLType, GraphQLResolveInfo,
+    GraphQLNonNull, GraphQLObjectType
+)
 
 import frappe
 from frappe.model.meta import Meta
@@ -19,7 +22,7 @@ def setup_default_resolvers(schema: GraphQLSchema):
     # Setup custom resolvers for DocTypes
     for type_name, gql_type in schema.type_map.items():
         dt = get_singular_doctype(type_name)
-        if not dt:
+        if not dt or not isinstance(gql_type, GraphQLObjectType):
             continue
 
         meta = frappe.get_meta(dt)


### PR DESCRIPTION
During the configuration of default resolvers for Frappe DocTypes and fields, the type_name is utilized to determine if it is a doctype. Additional resolver setup is then performed on the fields of the identified doctype. 

However, there are instances where GraphQLEnumTypes have similar names to doctypes, in which case, further resolver setup should not be applied. This PR ensures that resolver setup is only performed on GraphQLObjectTypes.